### PR TITLE
Add explicit aliasing for columns from the main table in createView

### DIFF
--- a/RedBean/QueryWriter/AQueryWriter.php
+++ b/RedBean/QueryWriter/AQueryWriter.php
@@ -404,7 +404,7 @@ abstract class RedBean_QueryWriter_AQueryWriter {
 
 		$joins = implode(" ", $joins);
 		foreach($columns as $k=>$column) {
-			$columns[$k]=$safeReferenceTable.".".$this->safeColumn($column);
+			$columns[$k]=$safeReferenceTable.".".$this->safeColumn($column)." as ".$this->safeColumn($column);
 		}
 		$columns = implode("\n,",array_merge($newcolumns,$columns));
 		$sql = "CREATE VIEW $viewID AS SELECT $columns FROM $safeReferenceTable $joins ";


### PR DESCRIPTION
Add explicit aliasing for columns from the main table in createView. SQLite before version 3.6 includes the table name in the default result column names, which breaks using the view. http://sqlite.org/changes.html That was over 3 years ago, but you can still easily run into old SQLite in the wild on Cent OS-based machines.
