### PR TITLE
Support of array structure of multiple selects and other multiple form elements

### DIFF
--- a/RedBean/Cooker.php
+++ b/RedBean/Cooker.php
@@ -76,8 +76,7 @@ class RedBean_Cooker {
                         
                     }
                     $array = $new;
-                    unset($new);
-                    print_r($array);
+                    unset($new);                    
                 }
                 
 		$beans = array();


### PR DESCRIPTION
Allow to use multiple select and natively build  forms that will manipulate several beans of same type.
For example
ownBean['type'] = 'bean';
ownBean['id'][0] = 1;
ownBean['id'][1] = 2;
ownBean['title'][0] = 'title1';
ownBean['title'][1] = 'title2';
