### PR TITLE
Minor regexp shrinkings

### DIFF
--- a/RedBean/OODB.php
+++ b/RedBean/OODB.php
@@ -144,7 +144,7 @@ class RedBean_OODB extends RedBean_Observable {
 			throw new RedBean_Exception_Security('Bean has incomplete Meta Information II');
 		}
 		//Pattern of allowed characters
-		$pattern = '/[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]/';
+		$pattern = '/[^a-z0-9_]/i';
 		//Does the type contain invalid characters?
 		if (preg_match($pattern,$bean->getMeta('type'))) {
 			throw new RedBean_Exception_Security('Bean Type is invalid');

--- a/RedBean/QueryWriter/MySQL.php
+++ b/RedBean/QueryWriter/MySQL.php
@@ -250,10 +250,10 @@ class RedBean_QueryWriter_MySQL extends RedBean_QueryWriter_AQueryWriter impleme
 			}
 			
 			
-			if (preg_match('/^\d\d\d\d\-\d\d-\d\d$/',$value)) {
+			if (preg_match('/^\d{4}\-\d\d-\d\d$/',$value)) {
 				return RedBean_QueryWriter_MySQL::C_DATATYPE_SPECIAL_DATE;
 			}
-			if (preg_match('/^\d\d\d\d\-\d\d-\d\d\s\d\d:\d\d:\d\d$/',$value)) {
+			if (preg_match('/^\d{4}\-\d\d-\d\d\s\d\d:\d\d:\d\d$/',$value)) {
 				return RedBean_QueryWriter_MySQL::C_DATATYPE_SPECIAL_DATETIME;
 			}
 		}

--- a/RedBean/QueryWriter/PostgreSQL.php
+++ b/RedBean/QueryWriter/PostgreSQL.php
@@ -171,10 +171,10 @@ class RedBean_QueryWriter_PostgreSQL extends RedBean_QueryWriter_AQueryWriter im
 		$this->svalue=$value;
 		
 		if ($flagSpecial && $value) {
-			if (preg_match('/^\d\d\d\d\-\d\d-\d\d$/',$value)) {
+			if (preg_match('/^\d{4}\-\d\d-\d\d$/',$value)) {
 				return RedBean_QueryWriter_PostgreSQL::C_DATATYPE_SPECIAL_DATE;
 			}
-			if (preg_match('/^\d\d\d\d\-\d\d-\d\d\s\d\d:\d\d:\d\d$/',$value)) {
+			if (preg_match('/^\d{4}\-\d\d-\d\d\s\d\d:\d\d:\d\d$/',$value)) {
 				return RedBean_QueryWriter_PostgreSQL::C_DATATYPE_SPECIAL_DATETIME;
 			}
 		}

--- a/RedBean/QueryWriter/SQLiteT.php
+++ b/RedBean/QueryWriter/SQLiteT.php
@@ -108,8 +108,8 @@ class RedBean_QueryWriter_SQLiteT extends RedBean_QueryWriter_AQueryWriter imple
 		if ($this->startsWithZeros($value)) return self::C_DATATYPE_TEXT;
 		if (is_numeric($value) && (intval($value)==$value) && $value<2147483648) return self::C_DATATYPE_INTEGER;
 		if ((is_numeric($value) && $value < 2147483648)
-				  || preg_match('/\d\d\d\d\-\d\d\-\d\d/',$value)
-				  || preg_match('/\d\d\d\d\-\d\d\-\d\d\s\d\d:\d\d:\d\d/',$value)
+				  || preg_match('/\d{4}\-\d\d\-\d\d/',$value)
+				  || preg_match('/\d{4}\-\d\d\-\d\d\s\d\d:\d\d:\d\d/',$value)
 		) {
 			return self::C_DATATYPE_NUMERIC;
 		}


### PR DESCRIPTION
Intended to reduce the size of the regexp and hopefully save PCRE a little work.

Also worth considering is adding the `S` flag to get PCRE to "study" regularly used regexps that have a definite length - I'm not sure if the regexps used in the QueryWriter classes are checked often enough to benefit from it or not however, but I know for sure that because of the nature of the regexp in `RedBean_OODB`, there would be zero benefit there.   Should be investigated and possibly benchmarked before implementing it, really.

Also, the regexp change in `RedBean_OODB` uses the `i` flag (case insensitive) to save on the number of characters needed for the regexp.  Don't be alarmed. :)
