### PR TITLE
Fixing bug. RedBean will correctly store an existing bean when...

### DIFF
--- a/RedBean/QueryWriter/AQueryWriter.php
+++ b/RedBean/QueryWriter/AQueryWriter.php
@@ -177,7 +177,7 @@ abstract class RedBean_QueryWriter_AQueryWriter {
 			$p[] = " {$this->safeColumn($uv["property"])} = ? ";
 			$v[]=$uv["value"];
 		}
-		$sql .= implode(",", $p ) ." WHERE id = ".intval($id);
+		$sql .= implode(",", $p ) ." WHERE id = ".(string) $id;
 		$this->adapter->exec( $sql, $v );
 		return $id;
 	}


### PR DESCRIPTION
... you do R::store($bean), if the bean's id is a BIGINT. This is because the query writer type casts the id string to an int before it adds it to the UPDATE statement.

I'm not sure if this is the right way to fix this or not, but it works for me. Here's the repro code:

> > > $bean = R::load('bean', $bean_id);
> > > $bean->some_other_column = 1234;
> > > R::store($bean);

R::store doesn't store any information if the bean's id is a BIGINT (e.g. something like 113989058729911) because the id gets type casted to an int and resolves to the INTMAX value.
