### PR TITLE
Enable FUSE models to overload properties

### DIFF
--- a/RedBean/OODBBean.php
+++ b/RedBean/OODBBean.php
@@ -122,6 +122,13 @@ class RedBean_OODBBean implements IteratorAggregate, ArrayAccess, Countable {
 		return $this;
 	}
 
+/**
+	 * Sets bean properties.  
+	 */
+  public function setProperties($properties) {
+    $this->properties = $properties;
+  }
+
 	/**
 	 * Very superficial export function
 	 * @return array $properties 
@@ -307,12 +314,12 @@ class RedBean_OODBBean implements IteratorAggregate, ArrayAccess, Countable {
 		if ($value===true) {
 			$value = '1';
 		}
-    		if(isset($this->__info['model'])) {
-      			$this->__info['model']->__set($property, $value);      
-    		}
-    		else {
-		  	$this->properties[$property] = $value;
-    		} 
+    if(isset($this->__info['model'])) {
+      $this->__info['model']->__set($property, $value);      
+    }
+    else {
+      $this->properties[$property] = $value;
+    } 
 	}
 
 	/**


### PR DESCRIPTION
We are working on a project with rich models, but we couldn't achive to overload properties on models, as the call to __set is made to OODBBean and dies there. We wanted OODBBean::__set to do all his work, but then pass the call to our Model::__set

We fixed OODBBean and added OODBBean::setProperties to achive this.

Our base model looks like this now:

```
class RedBeanModel extends RedBean_SimpleModel
{

    public funcion doSomething() {
    }

    public function __set( $prop, $value ) {
        $value = DoSomethingElseWithValue($value);
        // this mess is a workaround to redeban internals
        $properties = $this->bean->getProperties();
        $properties[$prop] = $value;
        $this->bean->setProperties($properties);
        $this->bean->$prop = $value;
    }
}
```

Hope it's useful to somebody else
