### PR TITLE
Silenced a notice warning.

### DIFF
--- a/RedBean/AssociationManager.php
+++ b/RedBean/AssociationManager.php
@@ -168,7 +168,9 @@ class RedBean_AssociationManager extends RedBean_Observable {
 				);
 				$sqlResult = array();
 				foreach( $sqlFetchKeys as $row ) {
-					$sqlResult[] = $row[$targetproperty];
+					if (isset($row[$targetproperty])) {
+						$sqlResult[] = $row[$targetproperty];
+					}
 				}
 				if ($cross) {
 					$sqlFetchKeys2 = $this->writer->selectRecord(


### PR DESCRIPTION
I've a query like:-

```
return R::getAll("SELECT t.tag, q.id, count(*) AS cnt
    FROM tags AS t, hta_tags AS qt, hta AS q
    WHERE t.id = qt.tag_id AND qt.hta_id = q.id
    GROUP BY t.id
    ORDER BY cnt DESC"
);
```

Which was causing the following:-

```
PHP Notice:  Undefined index: tags_id in rb.php on line 1820
```

Stuck in a guard to silence it.
