### PR TITLE
Code refactoring. Replaced N loop with native CUBRID SQL.

### DIFF
--- a/RedBean/QueryWriter/CUBRID.php
+++ b/RedBean/QueryWriter/CUBRID.php
@@ -414,9 +414,8 @@ class RedBean_QueryWriter_CUBRID extends RedBean_QueryWriter_AQueryWriter implem
 		$table = $this->safeTable($table);
 		$name = preg_replace('/\W/','',$name);
 		$column = $this->safeColumn($column);
-		foreach( $this->adapter->get("SHOW INDEX FROM $table ") as $ind) {
-			if ($ind['Key_name']===$name) return;
-		}
+		$index = $this->adapter->get("SELECT 1 as `exists` FROM db_index WHERE index_name = ? ",array($name));
+		if ($index && $index['exists']) return;   // positive number will return, 0 will continue.
 		try{ $this->adapter->exec("CREATE INDEX $name ON $table ($column) "); }catch(Exception $e){}
 	}
 	


### PR DESCRIPTION
As discussed with @gabordemooij at [Added index-check to prevent redundant logs](https://github.com/gabordemooij/redbean/commit/329e96742647f6b300bc7e9d3130131386aaf063#commitcomment-1460555), replaced N loop with a native CUBRID SQL statement.

Please run tests on Travis CI. Let me know if there is anything I can do more.

Btw, can you reply to my 'Your Feedback on implementing CUBRID "driver" for RedBeanPHP' email?
