### PR TITLE
Updated Composer autoload to be PSR-0 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "php": ">=5.2.0"
     },
     "autoload": {
-	"files":["RedBean/redbean.inc.php"]
+        "psr-0" : {
+            "RedBean_" : ""
+        }
     }
 }


### PR DESCRIPTION
This is important for performance reasons and it is a best practice.
