### PR TITLE
Fixed issue on PDO and OCI drivers

### DIFF
--- a/RedBean/Driver/OCI.php
+++ b/RedBean/Driver/OCI.php
@@ -1,50 +1,50 @@
 <?php
 /**
- * RedBean OCI Driver
+ * RedBean OCI Driver 
  *
  * @file				RedBean/Driver/OCI.php
  * @description			OCI Driver for RedBeanPHP. The OCI
- *						driver is required to facilitate a connection to
+ *						driver is required to facilitate a connection to 
  *						an Oracle database.
  *						Stephane Gerber
  * @license				BSD/GPLv2
  *
  * This source file is subject to the BSD/GPLv2 License that is bundled
- * with this source code in the file license.txt.
+ * with this source code in the file license.txt. 
  */
 class RedBean_Driver_OCI implements RedBean_Driver {
 
 	/**
 	 * Database connection string
-	 * @var string
+	 * @var string 
 	 */
 	private $dsn;
 
 	/**
-	 *
+	 * 
 	 * @var unknown_type
 	 */
 	private static $instance;
 
 	/**
-	 *
+	 * 
 	 * @var boolean
 	 */
 	private $debug = false;
-
+	
 	/**
 	 * Holds an instance of Logger implementation.
 	 * @var RedBean_Logger
-	 */
+	 */	
 	protected $logger = NULL;
 	/**
-	 *
+	 * 
 	 * @var unknown_type
 	 */
 	private $affected_rows;
 
 	/**
-	 *
+	 * 
 	 * @var unknown_type
 	 */
 	private $rs;
@@ -65,7 +65,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	 * @var boolean
 	 */
 	protected $isConnected = false;
-
+	
 	private $nlsDateFormat = 'YYYY-MM-DD HH24:MI:SS';
 	private $nlsTimeStampFormat = 'YYYY-MM-DD HH24:MI:SS.FF';
 
@@ -113,56 +113,56 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 			$this->connectInfo = array('pass' => $pass, 'user' => $user);
 		}
 	}
-
+	
 	/**
 	 * @todo add Documentation
-	 *
-	 * @return type
+	 * 
+	 * @return type 
 	 */
 	public function getNlsDateFormat(){
 		return $this->nlsDateFormat;
 	}
-
+	
 	/**
 	 * @todo add Documentation
-	 *
-	 * @return type
+	 * 
+	 * @return type 
 	 */
 	public function setNlsDateFormat($nlsDateFormat){
 		$this->nlsDateFormat = $nlsDateFormat;
 	}
-
+	
 	/**
 	 * @todo add Documentation
-	 *
-	 * @return type
+	 * 
+	 * @return type 
 	 */
 	public function getNlsTimestampFormat(){
 		return $this->nlsTimeStampFormat;
 	}
-
+	
 	/**
 	 * @todo add Documentation
-	 *
-	 * @return type
+	 * 
+	 * @return type 
 	 */
 	public function setNlsTimestampFormat($nlsTimestampFormat){
 		$this->nlsTimeStampFormat = $nlsTimestampFormat;
 	}
-
+	
 	/**
 	 * Gets RedBean_Logger object.
 	 *
 	 * @return RedBean_Logger
-	 */
+	 */	
 	public function setLogger( RedBean_Logger $logger ) {
 		$this->logger = $logger;
 	}
-
+	
 	/**
 	 * Toggles auto-commit.
-	 *
-	 * @param boolean $toggle
+	 * 
+	 * @param boolean $toggle 
 	 */
 	public function setAutoCommit($toggle) {
 		$this->autocommit = (bool) $toggle;
@@ -204,9 +204,9 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	 * $rs (always array). The number of rows affected (result of rowcount, if supported by database)
 	 * is stored in protected property $affected_rows. If the debug flag is set
 	 * this function will send debugging output to screen buffer.
-	 *
-	 * @throws RedBean_Exception_SQL
-	 *
+	 * 
+	 * @throws RedBean_Exception_SQL 
+	 * 
 	 * @param string $sql     the SQL string to be send to database server
 	 * @param array  $aValues the values that need to get bound to the query slots
 	 */
@@ -324,10 +324,10 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	 */
 	public function ErrorNo() {
 		$error = oci_error($this->statement);
-		if (is_array($error))
+		if (is_array($error)) 
 			return $error['code'];
-	    else
-			return null;
+	    else 
+			return null;		
 	}
 
 	/**
@@ -336,16 +336,16 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	 */
 	public function Errormsg() {
 		$error = oci_error($this->statement);
-		if (is_array($error))
+		if (is_array($error)) 
 			return $error['message'];
-	    else
+	    else 
 			return null;
-
+		
 	}
 
 	/**
 	 * Use oci binding to execute the binding and execute the query
-	 *
+	 * 
 	 *
 	 * @param string $sql	  SQL Code to execute
 	 * @param array  $aValues Values to bind to SQL query
@@ -379,7 +379,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 		if ($isInsert) {
 			oci_bind_by_name($this->statement, ':ID', $this->lastInsertedId, 20, SQLT_INT);
 		}
-
+		
 
 		if ($this->debug){
 			if (!$this->autocommit)
@@ -390,7 +390,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 			if (!$this->autocommit)
 				$result = @oci_execute($this->statement, OCI_NO_AUTO_COMMIT);  // data not committed
 			else
-				$result = @oci_execute($this->statement);
+				$result = @oci_execute($this->statement);			
 		}
 
 		if (!$result) {
@@ -405,14 +405,14 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	/**
 	 * Returns the underlying PHP OCI instance.
 	 *
-	 * @return OCI
+	 * @return OCI 
 	 */
 	public function getOCI() {
 		$this->connect();
 		return $this->connection;
 	}
 
-	// This function is used to be compatible with the Redbean actual behaviour. Oracle makes a difference between the
+	// This function is used to be compatible with the Redbean actual behaviour. Oracle makes a difference between the 
 	// two errors belows, Redbean doesnt'
 	private function mergeErrors($code) {
 		if ($code == self::OCI_UNIQUE_CONSTRAINT_VIOLATION)
@@ -462,7 +462,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 	 * where you can define your own log() method
 	 *
 	 * @param boolean $trueFalse turn on/off
-	 * @param RedBean_Logger $logger
+	 * @param RedBean_Logger $logger 
 	 *
 	 * @return void
 	 */
@@ -483,8 +483,8 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 
 	/**
 	 * Returns TRUE if the current PDO instance is connected.
-	 *
-	 * @return boolean $yesNO
+	 * 
+	 * @return boolean $yesNO 
 	 */
 	public function isConnected() {
 		if (!$this->isConnected && !$this->connection)
@@ -531,7 +531,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 
 	/**
 	 * Returns the version number of the database.
-	 * @return mixed $version
+	 * @return mixed $version 
 	 */
 	public function getDatabaseVersion() {
 		$this->connect();
@@ -541,7 +541,7 @@ class RedBean_Driver_OCI implements RedBean_Driver {
 		$e = oci_fetch_all($s, $output);
 		return $output['BANNER'][0];
 	}
-
+	
 
 }
 

--- a/RedBean/Driver/PDO.php
+++ b/RedBean/Driver/PDO.php
@@ -21,7 +21,7 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 	 * @var string
 	 */
 	protected $dsn;
-
+	
 	/**
 	 * Whether we are in debugging mode or not.
 	 * @var boolean
@@ -180,9 +180,9 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 	 * $rs (always array). The number of rows affected (result of rowcount, if supported by database)
 	 * is stored in protected property $affected_rows. If the debug flag is set
 	 * this function will send debugging output to screen buffer.
-	 *
-	 * @throws RedBean_Exception_SQL
-	 *
+	 * 
+	 * @throws RedBean_Exception_SQL 
+	 * 
 	 * @param string $sql     the SQL string to be send to database server
 	 * @param array  $aValues the values that need to get bound to the query slots
 	 */
@@ -277,7 +277,7 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 		return array_shift($arr);
 	}
 
-
+	
 
 	/**
 	 * Executes SQL code and allows key-value binding.
@@ -345,7 +345,7 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 	 * where you can define your own log() method
 	 *
 	 * @param boolean $trueFalse turn on/off
-	 * @param RedBean_Logger $logger
+	 * @param RedBean_Logger $logger 
 	 *
 	 * @return void
 	 */
@@ -452,7 +452,7 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 		$this->connect();
 		return $this->pdo;
 	}
-
+	
 	/**
 	 * Closes database connection by destructing PDO.
 	 */
@@ -460,17 +460,17 @@ class RedBean_Driver_PDO implements RedBean_Driver {
 		$this->pdo = null;
 		$this->isConnected = false;
 	}
-
+	
 	/**
 	 * Returns TRUE if the current PDO instance is connected.
-	 *
-	 * @return boolean $yesNO
+	 * 
+	 * @return boolean $yesNO 
 	 */
 	public function isConnected() {
 		if (!$this->isConnected && !$this->pdo) return false;
 		return true;
 	}
-
-
+	
+	
 }
 

--- a/RedBean/Facade.php
+++ b/RedBean/Facade.php
@@ -68,7 +68,7 @@ class RedBean_Facade {
 	 * @var RedBean_Plugin_BeanExport
 	 */
 	public static $exporter;
-
+	
 	/**
 	 * Holds the tag manager
 	 * @var RedBean_TagManager
@@ -86,9 +86,9 @@ class RedBean_Facade {
 	 */
 	public static $f;
 
-
+	
 	private static $strictType = true;
-
+	
 
 	/**
 	 * Get version
@@ -222,7 +222,7 @@ class RedBean_Facade {
 	 *
 	 */
 	public static function dispense( $type, $num = 1 ) {
-		if (!preg_match('/^[a-z0-9]+$/',$type) && self::$strictType) throw new RedBean_Exception_Security('Invalid type: '.$type);
+		if (!preg_match('/^[a-z0-9]+$/',$type) && self::$strictType) throw new RedBean_Exception_Security('Invalid type: '.$type); 
 		if ($num==1) {
 			return self::$redbean->dispense( $type );
 		}
@@ -232,8 +232,8 @@ class RedBean_Facade {
 			return $beans;
 		}
 	}
-
-
+	
+	
 	public static function setStrictTyping($trueFalse) {
 		self::$strictType = (boolean) $trueFalse;
 	}
@@ -304,7 +304,7 @@ class RedBean_Facade {
 	 */
 	public static function unassociate( $beans1,  $beans2 , $fast=false) {
 		return self::$associationManager->unassociate( $beans1, $beans2, $fast );
-
+		
 	}
 
 	/**
@@ -1048,7 +1048,7 @@ class RedBean_Facade {
 		}
 	}
 
-
+	
 
 
 	/**
@@ -1077,12 +1077,12 @@ class RedBean_Facade {
 		if (!$time) $time = time();
 		return @date('Y-m-d H:i:s',$time);
 	}
-
+	
 	/**
 	 * Optional accessor for neat code.
 	 * Sets the database adapter you want to use.
-	 *
-	 * @param RedBean_Adapter $adapter
+	 * 
+	 * @param RedBean_Adapter $adapter 
 	 */
 	public static function setDatabaseAdapter(RedBean_Adapter $adapter) {
 		self::$adapter = $adapter;
@@ -1092,22 +1092,22 @@ class RedBean_Facade {
 	 * Optional accessor for neat code.
 	 * Sets the database adapter you want to use.
 	 *
-	 * @param RedBean_QueryWriter $writer
+	 * @param RedBean_QueryWriter $writer 
 	 */
 	public static function setWriter(RedBean_QueryWriter $writer) {
 		self::$writer = $writer;
 	}
-
+	
 	/**
 	 * Optional accessor for neat code.
 	 * Sets the database adapter you want to use.
 	 *
-	 * @param RedBean_OODB $redbean
+	 * @param RedBean_OODB $redbean 
 	 */
 	public static function setRedBean(RedBean_OODB $redbean) {
 		self::$redbean = $redbean;
 	}
-
+	
 	/**
 	 * Optional accessor for neat code.
 	 * Sets the database adapter you want to use.
@@ -1127,7 +1127,7 @@ class RedBean_Facade {
 	public static function getWriter() {
 		return self::$writer;
 	}
-
+	
 	/**
 	 * Optional accessor for neat code.
 	 * Sets the database adapter you want to use.
@@ -1137,7 +1137,7 @@ class RedBean_Facade {
 	public static function getRedBean() {
 		return self::$redbean;
 	}
-
+	
 }
 
 //Compatibility with PHP 5.2 and earlier

--- a/RedBean/Logger.php
+++ b/RedBean/Logger.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * RedBean interface for Logging
- *
+ * 
  * @name    RedBean Logger
  * @file    RedBean/Logger.php
  * @author    Gabor de Mooij

--- a/RedBean/Logger/Default.php
+++ b/RedBean/Logger/Default.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * RedBean class for Logging
- *
+ * 
  * @name    RedBean Logger
  * @file    RedBean/Logger.php
  * @author    Gabor de Mooij


### PR DESCRIPTION
On the PDO driver, the setLogger method was typed to receive a RedBean_Logger_Default, making it impossible to use another Logger.
On the OCI, on the setDebug method, changed the code `new RedBean_Logger` for `new RedBean_Logger_Default` (can't instiate that interface :p).
The rest of the changes is documentation stuff
