### PR TITLE
Fix for naming foreign key naming overriding

### DIFF
--- a/RedBean/OODB.php
+++ b/RedBean/OODB.php
@@ -590,7 +590,7 @@ class RedBean_OODB extends RedBean_Observable {
 			$first = reset($ownAdditions);
 			if ($first instanceof RedBean_OODBBean) {
 				$alias = $bean->getMeta('sys.alias.'.$first->getMeta('type'));
-				if ($alias) $myFieldLink = $alias.'_id';
+				if ($alias) $myFieldLink = $alias;
 			}
 		}
 		foreach($ownAdditions as $addition) {


### PR DESCRIPTION
As far as I can tell, there is no way to override RB's propensity for using the "_id" suffix on FK identifiers. Personally, I like camel-case (`userId`, not `user_id`) and this fix allows for that by doing the following:

$obj = R::dispense("table");
$obj->setMeta("sys.alias.RelatedTableName", "foreignKeyName");
