### PR TITLE
Fix missing require() for Finder.php in redbean.inc.php

### DIFF
--- a/RedBean/redbean.inc.php
+++ b/RedBean/redbean.inc.php
@@ -69,6 +69,7 @@ require($dir.'Exception/Security.php');
 //Load Core functionality
 require($dir.'OODB.php');
 require($dir.'ToolBox.php');
+require($dir.'Finder.php');
 
 //Load extended functionality
 require($dir.'AssociationManager.php');


### PR DESCRIPTION
Since fffecee4e430dc4bd0b3c001d317509d4811744b, a finder is instantiated in `configureFacadeWithToolbox()` of the façade:

```
self::$finder = new RedBean_Finder( self::$toolbox );
```

For people using `redbean.inc.php`, this will throw an error because `Finder.php` was not `require()'d` in the file:

```
Fatal error: Class 'RedBean_Finder' not found in /vendor/RedBean/Facade.php on line 841
```

This fix fixes that problem.
