### PR TITLE
allow null values to trigger hasChanged() assertion

### DIFF
--- a/RedBean/OODBBean.php
+++ b/RedBean/OODBBean.php
@@ -780,9 +780,9 @@ class RedBean_OODBBean implements IteratorAggregate, ArrayAccess, Countable {
 	 * 
 	 * @return boolean 
 	 */
-	public function hasChanged($property) {
-		if (!isset($this->properties[$property])) return false;
-		return ($this->old($property) != $this->properties[$property]);
+	public function hasChanged($property){
+		return (array_key_exists($property, $this->properties)) ? 
+			$this->old($property) != $this->properties[$property] : false;
 	}
 	/**
 	 * Creates a N-M relation by linking an intermediate bean.


### PR DESCRIPTION
`isset($properties[$property])` returns false when the value is null.
null is a legitimate change for a database field. switching to `array_key_exists()` fixes this.
