### PR TITLE
old() uses array_key_exists instead of isset().

### DIFF
--- a/RedBean/OODBBean.php
+++ b/RedBean/OODBBean.php
@@ -840,7 +840,7 @@ class RedBean_OODBBean implements IteratorAggregate, ArrayAccess, Countable {
 	 */
 	public function old($property) {
 		$old = $this->getMeta('sys.orig', array());
-		if (isset($old[$property])) {
+		if (array_key_exists($property, $old)) {
 			return $old[$property];
 		}
 	}


### PR DESCRIPTION
Old() uses `isset()` to check if a property exists. However, the problem is that sometimes we legitimately have the value of `null` for a property and the property does exist.

If `isset` is used, if the property exists but the value is `null`, nothing is returned. I updated it to use `array_key_exists()` as this tells us whether the property exists or not and does not care about the value.
