### PR TITLE
Extended configuration

### DIFF
--- a/RedBean/Facade.php
+++ b/RedBean/Facade.php
@@ -313,9 +313,9 @@ class RedBean_Facade
 	 *
 	 * @return void
 	 */
-	public static function addDatabase( $key, $dsn, $user = NULL, $pass = NULL, $frozen = FALSE, $set_encoding = true )
+	public static function addDatabase( $key, $dsn, $user = NULL, $pass = NULL, $frozen = FALSE, $autoSetEncoding = TRUE )
 	{
-		self::$toolboxes[$key] = RedBean_Setup::kickstart( $dsn, $user, $pass, $frozen, (bool) $set_encoding );
+		self::$toolboxes[$key] = RedBean_Setup::kickstart( $dsn, $user, $pass, $frozen, $autoSetEncoding );
 	}
 
 	/**

--- a/RedBean/Setup.php
+++ b/RedBean/Setup.php
@@ -49,7 +49,7 @@ class RedBean_Setup
 	 *
 	 * @return RedBean_ToolBox
 	 */
-	public static function kickstart( $dsn, $username = NULL, $password = NULL, $frozen = FALSE, $set_encoding = true )
+	public static function kickstart( $dsn, $username = NULL, $password = NULL, $frozen = FALSE, $autoSetEncoding = TRUE )
 	{
 		if ( $dsn instanceof PDO ) {
 			$db  = new RedBean_Driver_PDO( $dsn );
@@ -60,7 +60,7 @@ class RedBean_Setup
 			if ( strpos( $dsn, 'oracle' ) === 0 ) {
 				$db = new RedBean_Driver_OCI( $dsn, $username, $password);
 			} else {
-				$db = new RedBean_Driver_PDO( $dsn, $username, $password, (bool) $set_encoding );
+				$db = new RedBean_Driver_PDO( $dsn, $username, $password, $autoSetEncoding );
 			}
 		}
 


### PR DESCRIPTION
Added option $autoSetEncoding (defaults TRUE). If it is FALSE, PDO::setEncoding() would not be called. 
This fixes the problem when some databases has text encoded in for example cp1251 but stored in utf8 fields and wre're unable to get readable text. ReadBean always set UTF8 encoding, therefore we're getting bad results (badly encoded and unreadable characters). I discovered that if I don't use function PDO::setEncoding, which actually do "SET names $encoding" then results are correct, mysql returns readable characters. Anyway, I really think, that user should have an option to disable "SET names" query. 

So my change only ads ability to disable SET NAMES query. By default it is enabled.
I'll be glad to see that feature in Readbean php. No matter - my code implementation or yours! I really love that lib!
