### PR TITLE
Fixed using condition without binding parameters and allow using an array for aliasing.

### DIFF
--- a/RedBean/Preloader.php
+++ b/RedBean/Preloader.php
@@ -84,13 +84,17 @@ class RedBean_Preloader
 	 */
 	private function extractTypeInfo( $typeInfo )
 	{
+		if ( is_array( $typeInfo ) && !isset( $typeInfo[1] ) ) {
+			$typeInfo[1] = NULL;
+		}
+		
 		list( $type, $sqlObj ) = ( is_array( $typeInfo ) ? $typeInfo : array( $typeInfo, NULL ) );
 
-		list( $sql, $bindings ) = $sqlObj;
-
-		if ( !is_array( $bindings ) ) {
-			$bindings = array();
+		if ( !isset($sqlObj[1]) ) {
+			$sqlObj[1] = array();
 		}
+		
+		list( $sql, $bindings ) = $sqlObj;
 
 		return array( $type, $sql, $bindings );
 	}


### PR DESCRIPTION
This PR fixes 2 things.
1. Previously, if we wanted to use the array form without an SQL snippet, it will fail:

``` php
R::preload($beans, array('manager' => array('people')));
```
1. It fixes the ability to have conditional snippets without bindings:

``` php
R::preload($beans, array('ownManager' => array('manager', array("name = 'john'"))))
```
