### PR TITLE
Set the first part of the sql snippet to 0 if it does not exist.

### DIFF
--- a/RedBean/Preloader.php
+++ b/RedBean/Preloader.php
@@ -87,8 +87,12 @@ class RedBean_Preloader
 		if ( is_array( $typeInfo ) && !isset( $typeInfo[1] ) ) {
 			$typeInfo[1] = NULL;
 		}
-		
+
 		list( $type, $sqlObj ) = ( is_array( $typeInfo ) ? $typeInfo : array( $typeInfo, NULL ) );
+		
+		if ( !isset($sqlObj[0]) ) {
+			$sqlObj[0] = NULL;
+		}
 
 		if ( !isset($sqlObj[1]) ) {
 			$sqlObj[1] = array();


### PR DESCRIPTION
It appears I forgot to set `$sqlObj[0]` to null if it does not exist in my last PR.

This should also fix notices that can show up in some cases.
