### PR TITLE
Ported RedUNIT specific Sqlite tests to PHPUnit (baby step)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit bootstrap="tests/bootstrap.php"
 		 backupGlobals="false"
 		 backupStaticAttributes="false"
 		 strict="true"

--- a/tests/RedBeanPHP/RedBeanBasicTestCase.php
+++ b/tests/RedBeanPHP/RedBeanBasicTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace RedBeanPHP;
+
+use RedBeanPHP\Facade as R;
+
+abstract class RedBeanBasicTestCase extends \PHPUnit_Framework_TestCase
+{
+
+    protected $dsn;
+
+    public function setup()
+    {
+        R::setup($this->dsn);
+    }
+
+    public function tearDown()
+    {
+        R::nuke();
+    }
+
+    protected function setGet($value)
+    {
+        $bean = R::dispense( "page" );
+        $bean->prop = $value;
+        $id = R::store( $bean );
+        $bean = R::load( "page", $id );
+
+        return $bean->prop;
+    }
+
+}

--- a/tests/RedBeanPHP/Sqlite/ForeignKeysTest.php
+++ b/tests/RedBeanPHP/Sqlite/ForeignKeysTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+
+/**
+ * port of RedUNIT_Sqlite_Foreignkeys
+ *
+ * @file    RedUNIT/Sqlite/Foreignkeys.php
+ * @desc    Tests the creation of foreign keys.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class ForeignKeysTest extends SqliteTestCase
+{
+    /**
+     * Test foreign keys with SQLite.
+     *
+     * @return void
+     */
+    public function testForeignKeysWithSQLite()
+    {
+        $book  = R::dispense( 'book' );
+        $page  = R::dispense( 'page' );
+        $cover = R::dispense( 'cover' );
+
+        list( $g1, $g2 ) = R::dispense( 'genre', 2 );
+
+        $g1->name          = '1';
+        $g2->name          = '2';
+        $book->ownPage     = array( $page );
+        $book->cover       = $cover;
+
+        $this->markTestIncomplete('Really strange: Line 43 throws: General error: 1 no such table: book_genre');
+
+        $book->sharedGenre = array( $g1, $g2 );
+        R::store( $book );
+
+        $fkbook  = R::getAll( 'pragma foreign_key_list(book)' );
+        $fkgenre = R::getAll( 'pragma foreign_key_list(book_genre)' );
+        $fkpage  = R::getAll( 'pragma foreign_key_list(page)' );
+
+        $this->assertSame('book_id', $fkpage[0]['from']);
+        $this->assertSame('id', $fkpage[0]['to']);
+        $this->assertSame('book', $fkpage[0]['table']);
+
+        $this->assertCount(2, $fkgenre);
+
+        if ($fkgenre[0]['from'] == 'book') {
+            $this->assertSame('id', $fkgenre[0]['to']);
+            $this->assertSame('book', $fkgenre[0]['table']);
+        }
+
+        if ($fkgenre[0]['from'] == 'genre') {
+            $this->assertSame('id', $fkgenre[0]['to']);
+            $this->assertSame('genre', $fkgenre[0]['table']);
+        }
+
+        $this->assertSame('cover_id', $fkbook[0]['from']);
+        $this->assertSame('id', $fkbook[0]['to']);
+        $this->assertSame('cover', $fkbook[0]['table']);
+    }
+}

--- a/tests/RedBeanPHP/Sqlite/FormatTest.php
+++ b/tests/RedBeanPHP/Sqlite/FormatTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+use RedBeanPHP\DefaultBeanFormatter;
+
+/**
+ * Port of RedUNIT_Sqlite_Formats
+ *
+ * @file    RedUNIT/Sqlite/Formats.php
+ * @desc    Tests bean formatting with various data types.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class FormatTest extends SqliteTestCase
+{
+    public function testUnnamed0()
+    {
+        $this->markTestIncomplete('Where is BF class?');
+
+        R::$writer->setBeanFormatter( new BF );
+
+        $bean         = R::dispense( 'page' );
+
+        $bean->rating = 1;
+
+        R::store( $bean );
+
+        $cols = R::$writer->getColumns( 'page' );
+
+        asrt( $cols['rating'], 'INTEGER' );
+
+        $bean->rating = 1.4;
+
+        R::store( $bean );
+
+        $cols = R::$writer->getColumns( 'page' );
+
+        asrt( $cols['rating'], 'NUMERIC' );
+
+        $bean->rating = '1999-02-02';
+
+        R::store( $bean );
+
+        $cols = R::$writer->getColumns( 'page' );
+
+        asrt( $cols['rating'], 'NUMERIC' );
+
+        $bean->rating = 'reasonable';
+
+        R::store( $bean );
+
+        $cols = R::$writer->getColumns( 'page' );
+
+        asrt( $cols['rating'], 'TEXT' );
+
+        R::$writer->setBeanFormatter( new DefaultBeanFormatter );
+    }
+}

--- a/tests/RedBeanPHP/Sqlite/ParameterBindTest.php
+++ b/tests/RedBeanPHP/Sqlite/ParameterBindTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+
+/**
+ * Port of RedUNIT_Sqlite_Parambind
+ *
+ * @file    RedUNIT/Sqlite/Parambind.php
+ * @desc    Tests\PDO parameter binding.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class ParameterBindTest extends SqliteTestCase
+{
+    /**
+     * Test parameter binding with SQLite.
+     *
+     * @return void
+     */
+    public function testParamBindWithSQLite()
+    {
+        $toolbox = R::$toolbox;
+        $adapter = $toolbox->getDatabaseAdapter();
+        $writer  = $toolbox->getWriter();
+        $redbean = $toolbox->getRedBean();
+        $pdo     = $adapter->getDatabase();
+
+        $this->assertSame(123, (int) $adapter->getCell( "SELECT 123" ));
+        $this->assertSame(987, (int) $adapter->getCell( "SELECT ?", array( "987" ) ));
+        $this->assertSame(989, (int) $adapter->getCell( "SELECT ?+?", array( "987", "2" ) ));
+        $this->assertSame(92, (int) $adapter->getCell(
+            "SELECT :numberOne+:numberTwo",
+            array( ":numberOne" => 42, ":numberTwo" => 50 ))
+        );
+
+        $pair = $adapter->getAssoc( "SELECT 'thekey','thevalue' " );
+
+        $this->assertTrue( is_array( $pair ));
+        $this->assertCount(1, $pair);
+        $this->assertArrayHasKey('thekey', $pair);
+        $this->assertSame("thevalue", $pair["thekey"]);
+
+        // testpack( 'Test whether we can properly bind and receive NULL values' );
+
+        $this->assertSame('NULL', $adapter->getCell( 'SELECT :nil ', array( ':nil' => 'NULL' ) ));
+        $this->assertNull( $adapter->getCell( 'SELECT :nil ', array( ':nil' => NULL ) ));
+
+        $this->assertSame('NULL', $adapter->getCell( 'SELECT ? ', array( 'NULL' ) ) );
+        $this->assertNull( $adapter->getCell( 'SELECT ? ', array( NULL ) ) );
+    }
+}

--- a/tests/RedBeanPHP/Sqlite/RebuildTest.php
+++ b/tests/RedBeanPHP/Sqlite/RebuildTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+
+/**
+ * Port of RedUNIT_Sqlite_Setget
+ *
+ * @file    RedUNIT/Sqlite/Setget.php
+ * @desc    Tests whether values are stored correctly.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class RebuildTest extends SqliteTestCase
+{
+    /**
+     * Test SQLite table rebuilding.
+     *
+     * @return void
+     */
+    public function testRebuilder()
+    {
+        $toolbox = R::$toolbox;
+        $adapter = $toolbox->getDatabaseAdapter();
+        $writer  = $toolbox->getWriter();
+        $redbean = $toolbox->getRedBean();
+        $pdo     = $adapter->getDatabase();
+
+        R::dependencies( array( 'page' => array( 'book' ) ) );
+
+        $book = R::dispense( 'book' );
+        $page = R::dispense( 'page' );
+        $book->ownPage[] = $page;
+        $id = R::store( $book );
+        $book = R::load( 'book', $id );
+
+        $this->assertCount(1, $book->ownPage);
+        $this->assertSame(1, (int) R::getCell( 'SELECT COUNT(*) FROM page' ));
+
+        R::trash( $book );
+        $this->assertSame(0, (int) R::getCell( 'SELECT COUNT(*) FROM page' ));
+
+        $book = R::dispense( 'book' );
+        $page = R::dispense( 'page' );
+        $book->ownPage[] = $page;
+
+        $id = R::store( $book );
+        $book = R::load( 'book', $id );
+        $this->assertCount(1, $book->ownPage);
+        $this->assertSame(1, (int) R::getCell( 'SELECT COUNT(*) FROM page' ));
+
+        $book->added = 2;
+        R::store( $book );
+        $book->added = 'added';
+        R::store( $book );
+        R::trash( $book );
+
+        $this->assertSame(0, (int) R::getCell( 'SELECT COUNT(*) FROM page' ));
+    }
+}

--- a/tests/RedBeanPHP/Sqlite/SetGetTest.php
+++ b/tests/RedBeanPHP/Sqlite/SetGetTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+
+/**
+ * Port of RedUNIT_Sqlite_Setget
+ *
+ * @file    RedUNIT/Sqlite/Setget.php
+ * @desc    Tests whether values are stored correctly.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class SetGetTest extends SqliteTestCase
+{
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testGetSet($value, $expected)
+    {
+        $bean = R::dispense( "page" );
+        $bean->prop = $value;
+        $id = R::store( $bean );
+        $bean = R::load( "page", $id );
+        $this->assertEquals($expected, $bean->prop);
+    }
+
+    public function dataProvider()
+    {
+        return [
+
+            // numbers
+            ["-1", "-1" ],
+            [-1, "-1" ],
+
+            ["-0.25", "-0.25" ],
+            [-0.25, "-0.25" ],
+
+            ["0.12345678", "0.12345678" ],
+            [0.12345678, "0.12345678" ],
+
+            ["-0.12345678", "-0.12345678" ],
+            [-0.12345678, "-0.12345678" ],
+
+            ["2147483647", "2147483647" ],
+            [2147483647, "2147483647" ],
+
+            [-2147483647, "-2147483647" ],
+            ["-2147483647", "-2147483647" ],
+
+            ["2147483648", "2147483648" ],
+            ["-2147483648", "-2147483648" ],
+
+            ["199936710040730", "199936710040730" ],
+            ["-199936710040730", "-199936710040730" ],
+
+            // dates
+            ["2010-10-11", "2010-10-11"],
+            ["2010-10-11 12:10", "2010-10-11 12:10"],
+            ["2010-10-11 12:10:11", "2010-10-11 12:10:11"],
+            ["x2010-10-11 12:10:11", "x2010-10-11 12:10:11"],
+
+            // booleans
+            [TRUE, "1"],
+            [FALSE, "0"],
+
+            ["TRUE", "TRUE"],
+            ["FALSE", "FALSE"],
+
+            // strings
+            ["a", "a" ],
+            [".", "." ],
+            ["\"", "\"" ],
+            ["just some text", "just some text" ],
+        ];
+    }
+
+    /**
+     * @dataProvider nullDataProvider
+     */
+    public function testNull($value, $expected)
+    {
+        $bean = R::dispense( "page" );
+        $bean->prop = $value;
+        $id = R::store( $bean );
+        $bean = R::load( "page", $id );
+        $this->assertTrue(($expected == $bean->prop));
+    }
+
+    public function nullDataProvider()
+    {
+        return [
+            ["NULL", "NULL" ],
+            ["NULL", "NULL" ],
+            [NULL, NULL],
+
+            [0, FALSE ],
+            [1, TRUE ],
+
+            [TRUE, TRUE ],
+            [FALSE, FALSE ]
+        ];
+    }
+
+}

--- a/tests/RedBeanPHP/Sqlite/WriterTest.php
+++ b/tests/RedBeanPHP/Sqlite/WriterTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace RedBeanPHP\Sqlite;
+
+use RedBeanPHP\SqliteTestCase;
+use RedBeanPHP\Facade as R;
+use RedBeanPHP\AssociationManager as AssociationManager;
+use RedBeanPHP\QueryWriter\SQLiteT as SQLiteT;
+use RedBeanPHP\RedException\SQL as SQL;
+
+/**
+ * WriterTest
+ *
+ * @file    test/Sqlite/WriterTest.php
+ * @desc    Tests Sqlite writer specific functions.
+ * @author  Gabor de Mooij and the RedBeanPHP Community
+ * @license New BSD/GPLv2
+ *
+ * (c) G.J.G.T. (Gabor) de Mooij and the RedBeanPHP Community.
+ * This source file is subject to the New BSD/GPLv2 License that is bundled
+ * with this source code in the file license.txt.
+ */
+class WriterTest extends SqliteTestCase
+{
+
+    /**
+     * Test scanning and coding.
+     *
+     * @return void
+     */
+    public function testScanningAndCoding()
+    {
+        $toolbox = R::$toolbox;
+        $adapter = $toolbox->getDatabaseAdapter();
+        $writer  = $toolbox->getWriter();
+        $redbean = $toolbox->getRedBean();
+        $pdo     = $adapter->getDatabase();
+
+        $a = new AssociationManager( $toolbox );
+
+        $this->assertFalse(in_array("testtable", $writer->getTables()));
+
+        $writer->createTable( "testtable" );
+
+        $this->assertTrue (in_array("testtable", $writer->getTables()));
+        $this->assertCount( 1, $writer->getColumns( "testtable" ));
+        $this->assertTrue ( in_array( "id", array_keys( $writer->getColumns( "testtable" ) ) ));
+        $this->assertFalse( in_array( "c1", array_keys( $writer->getColumns( "testtable" ) ) ));
+
+        $writer->addColumn( "testtable", "c1", 1 );
+
+        $this->assertCount( 2, $writer->getColumns( "testtable" ));
+        $this->assertTrue ( in_array( "c1", array_keys( $writer->getColumns( "testtable" ) ) ));
+
+        array_walk($writer->sqltype_typeno, function ($type, $key) use ($writer) {
+            $this->assertSame($type, $writer->code( $key ));
+        });
+
+        $this->assertSame(99, $writer->code( "unknown" ));
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( FALSE ));
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( NULL ));
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( 2 )  );
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( 255 ));
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( 256 ));
+        $this->assertSame(SQLiteT::C_DATATYPE_INTEGER,  $writer->scanType( -1 ) );
+        $this->assertSame(SQLiteT::C_DATATYPE_NUMERIC,  $writer->scanType( 1.5 ));
+        $this->assertSame(SQLiteT::C_DATATYPE_TEXT,     $writer->scanType( INF ));
+        $this->assertSame(SQLiteT::C_DATATYPE_TEXT,     $writer->scanType( "abc" ));
+        $this->assertSame(SQLiteT::C_DATATYPE_NUMERIC,  $writer->scanType( '2010-10-10' ));
+        $this->assertSame(SQLiteT::C_DATATYPE_NUMERIC,  $writer->scanType( '2010-10-10 10:00:00' ));
+        $this->assertSame(SQLiteT::C_DATATYPE_TEXT,     $writer->scanType( str_repeat( "lorem ipsum", 100 ) ));
+
+        $writer->widenColumn( "testtable", "c1", 2 );
+        $cols = $writer->getColumns( "testtable" );
+
+        $this->assertSame( 2, $writer->code( $cols["c1"] ));
+
+        // $id = $writer->insertRecord("testtable", array("c1"), array(array("lorem ipsum")));
+        $id  = $writer->updateRecord( "testtable", array( array( "property" => "c1", "value" => "lorem ipsum" ) ) );
+        $row = $writer->queryRecord( "testtable", array( "id" => array( $id ) ) );
+        $this->assertSame("lorem ipsum", $row[0]["c1"]);
+
+        $writer->updateRecord( "testtable", array( array( "property" => "c1", "value" => "ipsum lorem" ) ), $id );
+        $row = $writer->queryRecord( "testtable", array( "id" => array( $id ) ) );
+        $this->assertSame("ipsum lorem", $row[0]["c1"] );
+
+        $writer->deleteRecord( "testtable", array( "id" => array( $id ) ) );
+        $row = $writer->queryRecord( "testtable", array( "id" => array( $id ) ) );
+        $this->assertEmpty($row);
+    }
+
+    /**
+     * (FALSE should be stored as 0 not as '')
+     */
+    public function testZeroIssue()
+    {
+
+        $toolbox = R::$toolbox;
+        $redbean = $toolbox->getRedBean();
+        $bean = $redbean->dispense( "zero" );
+        $bean->zero  = FALSE;
+        $bean->title = "bla";
+        $redbean->store( $bean );
+        $this->assertCount(1, $redbean->find( "zero", array(), " zero = 0 " ));
+    }
+
+    /**
+     * Test ANSI92 issue in clearrelations
+     */
+    public function testClearrelations_ANSI92_issue()
+    {
+        $this->markTestIncomplete('This test has not been ported yet.');
+
+        $toolbox = R::$toolbox;
+        $redbean = $toolbox->getRedBean();
+        $a = new AssociationManager( $toolbox );
+
+        $book    = $redbean->dispense( "book" );
+        $author1 = $redbean->dispense( "author" );
+        $author2 = $redbean->dispense( "author" );
+        $book->title = "My First Post";
+        $author1->name = "Derek";
+        $author2->name = "Whoever";
+        $this->assertOnetoManyAssociation( $a, $book, $author1 );
+        $this->assertOnetoManyAssociation( $a, $book, $author2 );
+    }
+
+    /**
+     * Various.
+     * Tests whether writer correctly handles keyword 'group' and SQL state 23000 issue.
+     * These tests remain here to make sure issues 9 and 10 never happen again.
+     * However this bug will probably never re-appear due to changed architecture.
+     *
+     * @return void
+     */
+    public function testIssue9and10()
+    {
+        $this->markTestIncomplete('This test has not been ported yet.');
+
+        $this->skip();
+        $toolbox = R::$toolbox;
+        $redbean = $toolbox->getRedBean();
+        $adapter = $toolbox->getDatabaseAdapter();
+
+        $a = new AssociationManager( $toolbox );
+
+        $book    = $redbean->dispense( "book" );
+        $author1 = $redbean->dispense( "author" );
+        $author2 = $redbean->dispense( "author" );
+
+        $book->title = "My First Post";
+
+        $author1->name = "Derek";
+        $author2->name = "Whoever";
+
+        $a->associate( $book, $author1 );
+        $a->associate( $book, $author2 );
+
+        pass();
+
+        testpack( "Test Association Issue Group keyword (Issues 9 and 10)" );
+
+        $group       = $redbean->dispense( "group" );
+        $group->name = "mygroup";
+
+        $redbean->store( $group );
+
+        try {
+            $a->associate( $group, $book );
+
+            pass();
+        } catch ( SQL $e ) {
+            fail();
+        }
+
+        // Test issue SQL error 23000
+        try {
+            $a->associate( $group, $book );
+
+            pass();
+        } catch ( SQL $e ) {
+            print_r( $e );
+
+            fail();
+        }
+
+        asrt( (int) $adapter->getCell( "select count(*) from book_group" ), 1 ); //just 1 rec!
+    }
+
+    /**
+     * Test various.
+     * Test various somewhat uncommon trash/unassociate scenarios.
+     * (i.e. unassociate unrelated beans, trash non-persistant beans etc).
+     * Should be handled gracefully - no output checking.
+     *
+     * @todo  It seems this test was a black hole. Let's keep it failing for later investigation.
+     */
+    public function testUncommonScenarios()
+    {
+        $this->markTestIncomplete('This test has not been ported yet.');
+
+        $toolbox = R::$toolbox;
+        $redbean = $toolbox->getRedBean();
+
+        $a = new AssociationManager( $toolbox );
+
+        $book    = $redbean->dispense( "book" );
+        $author1 = $redbean->dispense( "author" );
+        $author2 = $redbean->dispense( "author" );
+
+        $book->title = "My First Post";
+
+        $author1->name = "Derek";
+        $author2->name = "Whoever";
+
+        $a->unassociate( $book, $author1 );
+        $a->unassociate( $book, $author2 );
+
+        $redbean->trash( $redbean->dispense( "bla" ) );
+
+        $bean = $redbean->dispense( "bla" );
+        $bean->name = 1;
+        $bean->id   = 2;
+
+        $redbean->trash( $bean );
+    }
+
+    /**
+     * Test special data types.
+     * @dataProvider specialDataTypesProvider
+     */
+    public function testSpecialDataTypes($value, $type)
+    {
+        $bean = R::dispense( 'bean' );
+        $bean->test_column = $value;
+        R::store( $bean );
+        $cols = R::getColumns( 'bean' );
+        $this->assertSame($type, $cols['test_column']);
+    }
+
+    public function specialDataTypesProvider()
+    {
+        return [
+            ['someday', 'TEXT'],
+            ['2011-10-10', 'NUMERIC']
+        ];
+    }
+
+    /**
+     * Emulates legacy function for use with older tests.
+     */
+    public function assertOnetoManyAssociation($a, \RedBeanPHP\OODBBean $bean1, \RedBeanPHP\OODBBean $bean2)
+    {
+        $type = $bean1->getMeta( "type" );
+
+        $a->clearRelations( $bean2, $type );
+        $a->associate( $bean1, $bean2 );
+
+        if ( count( $a->related( $bean2, $type ) ) === 1 ) {
+            // return $this;
+        } else {
+            throw new RedBean_Exception_SQL( "Failed to enforce 1-N Relation for $type " );
+        }
+    }
+}

--- a/tests/RedBeanPHP/SqliteTestCase.php
+++ b/tests/RedBeanPHP/SqliteTestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RedBeanPHP;
+
+use RedBeanPHP\RedBeanBasicTestCase;
+
+abstract class SqliteTestCase extends RedBeanBasicTestCase
+{
+
+    protected $dsn = 'sqlite:/tmp/oodb.db';
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+$loader = require __DIR__.'/../vendor/autoload.php';
+$loader->add('RedBeanPHP', __DIR__);


### PR DESCRIPTION
![coverage-sqlite](https://f.cloud.github.com/assets/227395/1708919/1dd6ce5e-6116-11e3-9428-6e6d5e008b84.png)

Some tests were marked as skipped. I need some feedback about these tests. They are not passing due to an error related to `$bean->sharedEntity`. Need some help to understanding why these errors are happening. Are RedUNIT related tests passing?

Would be great if somebody with more RedBean Karma review it very carefully. Coverage is automatically generated at `build/logs/coverage/index.html`.

TODO:
- update doc blocks. I left the old doc blocks for historical reasons.
- some tests are too long, should we split these tests into smaller ones?
