### PR TITLE
Making sure mb_strlen is enabled before using it

### DIFF
--- a/RedBeanPHP/QueryWriter/MySQL.php
+++ b/RedBeanPHP/QueryWriter/MySQL.php
@@ -219,18 +219,22 @@ class MySQL extends AQueryWriter implements QueryWriter
 				return MySQL::C_DATATYPE_DOUBLE;
 			}
 		}
+		
+		if( function_exists('mb_strlen') ) {
 
-		if ( mb_strlen( $value, 'UTF-8' ) <= 191 ) {
-			return MySQL::C_DATATYPE_TEXT7;
-		}
+			if ( mb_strlen( $value, 'UTF-8' ) <= 191 ) {
+				return MySQL::C_DATATYPE_TEXT7;
+			}
 
-		if ( mb_strlen( $value, 'UTF-8' ) <= 255 ) {
-			return MySQL::C_DATATYPE_TEXT8;
-		}
+			if ( mb_strlen( $value, 'UTF-8' ) <= 255 ) {
+				return MySQL::C_DATATYPE_TEXT8;
+			}
 
-		if ( mb_strlen( $value, 'UTF-8' ) <= 65535 ) {
-			return MySQL::C_DATATYPE_TEXT16;
-		}
+			if ( mb_strlen( $value, 'UTF-8' ) <= 65535 ) {
+				return MySQL::C_DATATYPE_TEXT16;
+			}
+
+		{
 
 		return MySQL::C_DATATYPE_TEXT32;
 	}


### PR DESCRIPTION
mb_strlen is not enabled by default. It’s better to run a check and fallback otherwise it throws 500. 