### PR TITLE
Installation process has been written in readme file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,22 @@ RedBeanPHP is an easy to use ORM tool for PHP.
 * No configuration, just fire and forget
 * No complicated package tools, no autoloaders, just ONE file
 
+Installation via Composer:
+-------------------------
+
+Just open your composer.json file and add the package name ```(e.g. "gabordemooij/redbean": "dev-master")``` in your require list.
+
+```json
+{
+    "require": {
+        "gabordemooij/redbean": "dev-master"
+    }
+}
+```
+
+If you not using composer then [try it.](http://redbeanphp.com/install)
+
+
 Quick Example
 -------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ RedBeanPHP is an easy to use ORM tool for PHP.
 * No configuration, just fire and forget
 * No complicated package tools, no autoloaders, just ONE file
 
-Installation via Composer:
+Installation via Composer
 -------------------------
 
 Just open your composer.json file and add the package name ```(e.g. "gabordemooij/redbean": "dev-master")``` in your require list.


### PR DESCRIPTION
I have written the installation process via composer in README.markdown file. So anyone can easily install RedBeanPHP via composer without finding the package from packagist.

And also put a link of manual install page (RedBeanPHP official site). Hope that will be helpful for user to install the RedBeanPHP.