### PR TITLE
fix PostgreSQL's getColumns()

### DIFF
--- a/RedBeanPHP/QueryWriter/PostgreSQL.php
+++ b/RedBeanPHP/QueryWriter/PostgreSQL.php
@@ -184,7 +184,7 @@ class PostgreSQL extends AQueryWriter implements QueryWriter
 	{
 		$table      = $this->esc( $table, TRUE );
 
-		$columnsRaw = $this->adapter->get( "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='$table'" );
+		$columnsRaw = $this->adapter->get( "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='$table' AND table_schema = ANY( current_schemas( FALSE ) )" );
 
 		$columns = array();
 		foreach ( $columnsRaw as $r ) {


### PR DESCRIPTION
getColumns() in PostgreSQL QueryWriter used to return columns for all
tables with the same names, even if outside the current schemas