### PR TITLE
Improve $factory parameter documentation

### DIFF
--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -28,7 +28,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	/**
 	 * Factory function to create instance of Simple Model, if any.
 	 *
-	 * @var closure
+	 * @var \Closure
 	 */
 	private static $factory = null;
 
@@ -50,7 +50,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 * Sets the factory function to create the model when using FUSE
 	 * to connect a bean to a model.
 	 *
-	 * @param closure $factory factory function
+	 * @param \Closure $factory factory function
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
When using PhpStorm 10.0.3 and PHP 7.0.1 for linting I get his error on the rb.php file:

```"Function name must be callable - a string, Closure or class implementing __invoke, currently \RedBeanPHP\BeanHelper\closure"```

![PhpStorm 10.0.3 + PHP 7.0.1 lint error](http://i.imgur.com/5wYMlGL.png)

Turns out the fix is as easy as improving the documentation for the $factory parameter from closure to \Closure.

This way the IDE stops thinking RedBeanPHP is broken.