### PR TITLE
Auto unbox() SimpleModel arrays

### DIFF
--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -62,6 +62,9 @@ abstract class Repository
 				$this->processEmbeddedBean( $embeddedBeans, $bean, $property, $value );
 				$bean->setMeta("sys.typeof.{$property}", $value->getMeta('type'));
 			} elseif ( is_array( $value ) ) {
+				foreach($value as &$item) {
+					$item = ( $item instanceof SimpleModel ) ? $item->unbox() : $item;
+				}
 				$originals = $bean->moveMeta( 'sys.shadow.' . $property, array() );
 				if ( strpos( $property, 'own' ) === 0 ) {
 					list( $ownAdditions, $ownTrashcan, $ownresidue ) = $this->processGroups( $originals, $value, $ownAdditions, $ownTrashcan, $ownresidue );

--- a/testing/RedUNIT/Base/Misc.php
+++ b/testing/RedUNIT/Base/Misc.php
@@ -521,4 +521,15 @@ class Misc extends Base
 		asrt( $beanA->equals( $beanB ), FALSE );
 		asrt( $beanB->equals( $beanA ), FALSE );
 	}
+  
+  public function testSharedListsAutoUnbox() {
+    $bean = R::dispense( 'bean' );
+    $bean->sharedBoxedbeanList[] = new Model_Boxedbean();
+    try {
+		  R::store( $bean );
+			pass();
+		} catch ( \Exception $e ) {
+      fail();
+		}
+  }
 }

--- a/testing/RedUNIT/Base/Misc.php
+++ b/testing/RedUNIT/Base/Misc.php
@@ -523,17 +523,20 @@ class Misc extends Base
 		asrt( $beanB->equals( $beanA ), FALSE );
 	}
   
-    /**
-     * Test if adding SimpleModles to a shared list wil auto unbox them.
-     */
-    public function testSharedListsAutoUnbox() {
-      $bean = R::dispense( 'bean' );
-      $bean->sharedBoxedbeanList[] = new SimpleModel();
-      try {
-		    R::store( $bean );
-			  pass();
-		  } catch ( \Exception $e ) {
-        fail();
-		  }
-    }
+	/**
+	 * Test if adding SimpleModles to a shared list will auto unbox them.
+	 */
+	public function testSharedListsAutoUnbox() {
+		$boxedBean = R::dispense( 'boxedbean' );
+		$bean = R::dispense( 'bean' );
+		$model = new SimpleModel();
+		$model->loadBean($boxedBean);
+		$bean->ownBoxedbeanList[] = $model;
+		try {
+			R::store( $bean );
+			pass();
+		} catch ( \Exception $e ) {
+			fail();
+		}
+	}
 }

--- a/testing/RedUNIT/Base/Misc.php
+++ b/testing/RedUNIT/Base/Misc.php
@@ -13,6 +13,7 @@ use RedBeanPHP\QueryWriter as QueryWriter;
 use RedBeanPHP\RedException as RedException;
 use RedBeanPHP\RedException\SQL as SQL;
 use RedBeanPHP\Driver\RPDO as RPDO;
+use RedBeanPHP\SimpleModel as SimpleModel;
 
 /**
  * Misc
@@ -522,14 +523,17 @@ class Misc extends Base
 		asrt( $beanB->equals( $beanA ), FALSE );
 	}
   
-  public function testSharedListsAutoUnbox() {
-    $bean = R::dispense( 'bean' );
-    $bean->sharedBoxedbeanList[] = new Model_Boxedbean();
-    try {
-		  R::store( $bean );
-			pass();
-		} catch ( \Exception $e ) {
-      fail();
-		}
-  }
+    /**
+     * Test if adding SimpleModles to a shared list wil auto unbox them.
+     */
+    public function testSharedListsAutoUnbox() {
+      $bean = R::dispense( 'bean' );
+      $bean->sharedBoxedbeanList[] = new SimpleModel();
+      try {
+		    R::store( $bean );
+			  pass();
+		  } catch ( \Exception $e ) {
+        fail();
+		  }
+    }
 }


### PR DESCRIPTION
In case we have SimpleModel elements when storing bean with lists the following error occurs:
PHP Catchable fatal error:  Object of class [MODEL_NAME] could not be converted to string in /opt/projects/php/sbm/back-end/vendor/gabordemooij/redbean/RedBeanPHP/Repository.php on line 108

So this patch will walk trough all items in the list and unbox() them in case they are simple models. That way it is no longer required to call unbox() when adding new items in the "shared" (or "own") bean lists.