### PR TITLE
Friendly display PDOException message

### DIFF
--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -309,9 +309,13 @@ class RPDO implements Driver
 			$this->pdo->setAttribute( \PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC );
 			$this->isConnected = TRUE;
 		} catch ( \PDOException $exception ) {
-			$matches = array();
-			$dbname  = ( preg_match( '/dbname=(\w+)/', $this->dsn, $matches ) ) ? $matches[1] : '?';
-			throw new \PDOException( 'Could not connect to database (' . $dbname . ').', $exception->getCode() );
+			if ( preg_match( '/Access denied/', $exception->getMessage() ) ) {
+				$matches = array();
+				$dbname  = ( preg_match( '/dbname=(\w+)/', $this->dsn, $matches ) ) ? $matches[1] : '?';
+				throw new \PDOException( 'Could not connect to database (' . $dbname . ').', $exception->getCode() );
+			} else {
+				throw new \PDOException( $exception->getMessage(), $exception->getCode() );
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @gabordemooij 

I add a condition to display PDOException message.

Yesterday I used `R::setup` and saw `Could not connect to database (my_db)`, I repeated check my mysql connect information, but there was nothing wrong. At last, I google and `php -i | grep pdo` then found my `pdo_mysql` extension not loaded. so, I make this PR and friendly display PDOException message.

Please review it, thanks.

e.g.

When not load pdo_x extension, the message `could not find driver` is better than `Could not connect to database (my_db)`
```php
[38] boris> extension_loaded("pdo_pgsql");
// false
[39] boris> try{ new PDO('pgsql:'); } catch (Exception $err){ var_dump($err->getMessage()); };
string(21) "could not find driver"
```
And when host cannot resolve and more. 
```php
[56] boris> try{ new PDO('mysql:host=localhostx;port=3307', 'root'); } catch (Exception $err){ var_dump($err->getMessage()); };
string(94) "SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known"

[57] boris> try{ new PDO('mysql:host=127.0.0.1;port=3307'); } catch (Exception $err){ var_dump($err->getMessage()); };string(41) "SQLSTATE[HY000] [2002] Connection refused"
```

Only except username or password not matched.
```php
[65] boris> try{ new PDO('mysql:host=127.0.0.1;port=3306', 'root', '123456'); } catch (Exception $err){ var_dump($err->getMessage()); };
string(86) "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES)"
```
