### PR TITLE
Add check if $property is field link

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1068,6 +1068,8 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 		$hasSQL         = ($this->withSql !== '' || $this->via !== NULL);
 		$exists         = isset( $this->properties[$property] );
 		$fieldLink      = $property . '_id';
+		$isFieldLink	= (($pos = strrpos($property, '_id')) !== FALSE) && isset( $this->properties[($fieldName = substr($property, 0, $pos))]);
+
 
 		if ( ($isOwn || $isShared) &&  (!$exists || $hasSQL || $differentAlias) ) {
 
@@ -1104,6 +1106,12 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 				throw new RedException( 'Cannot cast to bean.' );
 			}
 		}
+		
+		if ( $isFieldLink && array_key_exists( $fieldName, $this->properties ) ){
+			unset( $this->properties[ $fieldName ]);
+			$this->properties[ $property ] = NULL;
+		}
+
 
 		if ( $value === FALSE ) {
 			$value = '0';

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1068,7 +1068,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 		$hasSQL         = ($this->withSql !== '' || $this->via !== NULL);
 		$exists         = isset( $this->properties[$property] );
 		$fieldLink      = $property . '_id';
-		$isFieldLink	= (($pos = strrpos($property, '_id')) !== FALSE) && isset( $this->properties[($fieldName = substr($property, 0, $pos))]);
+		$isFieldLink	= (($pos = strrpos($property, '_id')) !== FALSE) && array_key_exists( ($fieldName = substr($property, 0, $pos)), $this->properties );
 
 
 		if ( ($isOwn || $isShared) &&  (!$exists || $hasSQL || $differentAlias) ) {
@@ -1107,7 +1107,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 			}
 		}
 		
-		if ( $isFieldLink && array_key_exists( $fieldName, $this->properties ) ){
+		if ( $isFieldLink ){
 			unset( $this->properties[ $fieldName ]);
 			$this->properties[ $property ] = NULL;
 		}


### PR DESCRIPTION
Check if given property name is a field link and clear the linked object. That prevents the old value of field getting stored.

Consider the following code:
```php
R::setup(/*options*/);  
R::setAutoResolve(TRUE);  
$bean = R::load('type', 1); //Database table type has an attribute link that references another table
$bean->link_id = $submittedIDOfLinkedBean;  
R::store($bean);  
```

Then the `link` property eventually does not get updated, since `link` is set to the OODBBean of the old object and on `R::store($bean)` the `id`of `link` object is read and overwrites the change made to `link_id`.