### PR TITLE
Update README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,14 @@ Just open your composer.json file and add the package name ```(e.g. "gabordemooi
 }
 ```
 
-If you not using composer then [try it.](http://redbeanphp.com/install)
+**NOTE**: 
+You will find many examples on the redbean website make use of RedBean's `R` class. Because of namespaced autoloading in composer, this class will be available as `\RedbeanPHP\R` instead of `R`. If you desire to use the much shorter `R` class, you can utilize PHP's `class_alias()` function to take care of the job for you as so:
+
+```php
+class_alias('\RedBeanPHP\R','\R');
+```
+
+If you are not using composer then [try it.](http://redbeanphp.com/install)
 
 
 Quick Example


### PR DESCRIPTION
RE #537 

Add's a note about the caveat of using redbean with composer, and a simple workaround to use the `R` class with composer instead of `RedbeanPHP\R`, which trips up alot of newbies.  (Dear BDFL, please add this note to the website when you have time)

\cc: @gabordemooij