### PR TITLE
New feature on RDefault.php (logger count)

### DIFF
--- a/RedBeanPHP/Logger/RDefault.php
+++ b/RedBeanPHP/Logger/RDefault.php
@@ -79,6 +79,16 @@ class RDefault implements Logger
 	{
 		return $this->logs;
 	}
+	
+	/**
+	 * Returns the internal log array count.
+	 * The internal log array is where all log messages are stored.
+	 *
+	 * @return int
+	 */
+	public function count(){
+	    return count($this->logs);
+        }
 
 	/**
 	 * Clears the internal log array, removing all


### PR DESCRIPTION
Add new function count on Logger
Can be used as
R::debug( TRUE, 3 );
//CODE//
$logs = R::getDatabaseAdapter()->getDatabase()->getLogger()->count();
echo 'RB queries: '.$logs;