### PR TITLE
Minor fix to the internal documentation of Facade::convertToBean method

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1148,7 +1148,7 @@ class Facade
 	 * @param array  $row       one row from the database
 	 * @param string $metamask  metamask (see convertToBeans)
 	 *
-	 * @return array
+	 * @return RedBeanPHP\OODBBean
 	 */
 	public static function convertToBean( $type, $row, $metamask = NULL )
 	{


### PR DESCRIPTION
The convertToBean method returns a OODBBean object, right?