### PR TITLE
Adding $sql parameter and LIMIT 1 to findOrCreate()

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1877,9 +1877,9 @@ class Facade
 	 *
 	 * @return OODBBean
 	 */
-	public static function findOrCreate( $type, $like = array() )
+	public static function findOrCreate( $type, $like = array(), $sql = '' )
 	{
-		return self::$finder->findOrCreate( $type, $like );
+		return self::$finder->findOrCreate( $type, $like, $sql = '' );
 	}
 
 	/**

--- a/RedBeanPHP/Finder.php
+++ b/RedBeanPHP/Finder.php
@@ -200,9 +200,10 @@ class Finder
 	 *
 	 * @return OODBBean
 	 */
-	public function findOrCreate( $type, $like = array() )
+	public function findOrCreate( $type, $like = array(), $sql = '' )
 	{
-			$beans = $this->findLike( $type, $like );
+			$sql = $this->toolbox->getWriter()->glueLimitOne( $sql );
+			$beans = $this->findLike( $type, $like, $sql );
 			if ( count( $beans ) ) {
 				$bean = reset( $beans );
 				return $bean;


### PR DESCRIPTION
As said in the commits, the $sql parameter will allow to sort beans so that we get the one we want in case it finds one. For example:

```php
$bean = R::findOrCreate("bean", [ "user_id" => 1 ], " ORDER BY mycolumn DESC ");
```

The LIMIT 1 (using ```glueLimitOne()```) will make the SQL query much faster and make the script use less memory since we're only returning the first bean found.