### PR TITLE
Fix documentation of findOne method

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -790,7 +790,7 @@ class Facade
 	 * @param string $sql      SQL query to find the desired bean, starting right after WHERE clause
 	 * @param array  $bindings array of values to be bound to parameters in query
 	 *
-	 * @return OODBBean
+	 * @return OODBBean|NULL
 	 */
 	public static function findOne( $type, $sql = NULL, $bindings = array() )
 	{

--- a/RedBeanPHP/Finder.php
+++ b/RedBeanPHP/Finder.php
@@ -103,7 +103,7 @@ class Finder
 	 * @param string $sql      sql    SQL query to find the desired bean, starting right after WHERE clause
 	 * @param array  $bindings values array of values to be bound to parameters in query
 	 *
-	 * @return OODBBean
+	 * @return OODBBean|NULL
 	 */
 	public function findOne( $type, $sql = NULL, $bindings = array() )
 	{


### PR DESCRIPTION
Fix documentation of findOne method.

Came across this error when phpstan pointed that the comparison with NULL would always evaluate to false. Fixing the documentation fixes the problem with phpstan.