### PR TITLE
Remove unnecessary count in SELECT

### DIFF
--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1036,7 +1036,7 @@ abstract class AQueryWriter
 		$score = ( $all ) ? count( $tagList ) : 1;
 
 		$sql = "
-			SELECT {$table}.*, count({$table}.id) FROM {$table}
+			SELECT {$table}.* FROM {$table}
 			INNER JOIN {$assocTable} ON {$assocField} = {$table}.id
 			INNER JOIN tag ON {$assocTable}.tag_id = tag.id
 			WHERE tag.title IN ({$slots})


### PR DESCRIPTION
When using R::tagged() or R::taggedAll() it added a 'count(`bean_type`.id)' property to the beans it returned, simply got rid of that.