### PR TITLE
Remove $NULL to directly return NULL

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1097,8 +1097,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 			$this->all        = FALSE;
 			$this->via        = NULL;
 
-			$NULL = NULL;
-			return $NULL;
+			return NULL;
 		}
 		$hasAlias       = (!is_null($this->aliasName));
 		$differentAlias = ($hasAlias && $isOwn && isset($this->__info['sys.alias.'.$listName])) ?


### PR DESCRIPTION
Unless I missed something, this is not necessary so I removed it.