### PR TITLE
Allow to specify partial beans in R::setup() and R::addDatabase()

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -225,13 +225,13 @@ class Facade
 	 *
 	 * @return ToolBox
 	 */
-	public static function setup( $dsn = NULL, $username = NULL, $password = NULL, $frozen = FALSE )
+	public static function setup( $dsn = NULL, $username = NULL, $password = NULL, $frozen = FALSE, $partialBeans = FALSE )
 	{
 		if ( is_null( $dsn ) ) {
 			$dsn = 'sqlite:/' . sys_get_temp_dir() . '/red.db';
 		}
 
-		self::addDatabase( 'default', $dsn, $username, $password, $frozen );
+		self::addDatabase( 'default', $dsn, $username, $password, $frozen, $partialBeans );
 		self::selectDatabase( 'default' );
 
 		return self::$toolbox;
@@ -324,7 +324,7 @@ class Facade
 	 *
 	 * @return void
 	 */
-	public static function addDatabase( $key, $dsn, $user = NULL, $pass = NULL, $frozen = FALSE )
+	public static function addDatabase( $key, $dsn, $user = NULL, $pass = NULL, $frozen = FALSE, $partialBeans = FALSE )
 	{
 		if ( isset( self::$toolboxes[$key] ) ) {
 			throw new RedException( 'A database has already been specified for this key.' );
@@ -356,6 +356,10 @@ class Facade
 		$writerClass = '\\RedBeanPHP\\QueryWriter\\'.$writers[$wkey];
 		$writer      = new $writerClass( $adapter );
 		$redbean     = new OODB( $writer, $frozen );
+		
+		if ( $partialBeans ) {
+			$redbean->getCurrentRepository()->usePartialBeans( $partialBeans );
+		}
 
 		self::$toolboxes[$key] = new ToolBox( $redbean, $adapter, $writer );
 	}


### PR DESCRIPTION
This is especially useful when using multiple databases.

I'm first checking if $partialBeans is TRUE before calling usePartialBeans().
It's true that we could just call usePartialBeans() even if partialBeans is FALSE but I thought it would be a waste since it's FALSE by default. If change it to TRUE by default at some point (not sure this will ever happen) we'd have to reverse the check.

The docs and tests need to be updated to reflect the change.