### PR TITLE
Prevent R::selectDatabase from changing BeanHelper

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1540,7 +1540,7 @@ class Facade
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );
-		if (empty(self::$redbean->getBeanHelper())) {
+		if (self::$redbean->getBeanHelper() != NULL) {
 			self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
 		}
 		self::$duplicationManager = new DuplicationManager( self::$toolbox );

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1540,7 +1540,7 @@ class Facade
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );
-		if (self::$redbean->getBeanHelper() != NULL) {
+		if (self::$redbean->getBeanHelper() == NULL) {
 			self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
 		}
 		self::$duplicationManager = new DuplicationManager( self::$toolbox );

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1540,7 +1540,9 @@ class Facade
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );
-		self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
+		if (empty(self::$redbean->getBeanHelper())) {
+			self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
+		}
 		self::$duplicationManager = new DuplicationManager( self::$toolbox );
 		self::$tagManager         = new TagManager( self::$toolbox );
 		return $oldTools;


### PR DESCRIPTION
When you use R::addDatabase(), you can't set the beanHelper on the fly without having to do a R::selectDatabase() first because R::selectDatabase() will first call configureFacadeWithToolbox() which will remove the BeanHelper you've set yourself.