### PR TITLE
Add option to use each bean OODB

### DIFF
--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -64,7 +64,11 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 */
 	public function getToolbox()
 	{
-		return Facade::getToolBox();
+		if ( Facade::$useBeanOODB ) {
+			return $toolbox = Facade::$toolboxes[$this->database];
+		} else {
+			return Facade::getToolBox();
+		}
 	}
 
 	/**
@@ -104,6 +108,11 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 */
 	public function getExtractedToolbox()
 	{
-		return Facade::getExtractedToolbox();
+		if ( Facade::$useBeanOODB ) {
+			$toolbox = Facade::$toolboxes[$this->database];
+		        return array( $toolbox->getRedbean(), $toolbox->getDatabaseAdapter(), $toolbox->getWriter(), $toolbox );
+		} else {
+			return Facade::getExtractedToolbox();
+		}
 	}
 }

--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -31,6 +31,11 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 * @var \Closure
 	 */
 	private static $factory = null;
+	
+	/**
+	 * @var string
+	 */
+	private $databaseKey = NULL;
 
 	/**
 	 * Factory method using a customizable factory function to create
@@ -58,6 +63,19 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	{
 		self::$factory = $factory;
 	}
+	
+	/**
+	 * Sets the name of the database to get specific toolbox if needed.
+	 *
+	 * For more details regarding the name, consult R::addDatabase().
+	 * @see Facade::addDatabase
+	 *
+	 * @return void
+	 */
+	public function __construct( $databaseKey )
+	{
+		$this->database = $databaseKey;
+	}
 
 	/**
 	 * @see BeanHelper::getToolbox
@@ -65,7 +83,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	public function getToolbox()
 	{
 		if ( Facade::$useBeanOODB ) {
-			return $toolbox = Facade::$toolboxes[$this->database];
+			return $toolbox = Facade::$toolboxes[$this->databaseKey];
 		} else {
 			return Facade::getToolBox();
 		}
@@ -109,7 +127,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	public function getExtractedToolbox()
 	{
 		if ( Facade::$useBeanOODB ) {
-			$toolbox = Facade::$toolboxes[$this->database];
+			$toolbox = Facade::$toolboxes[$this->databaseKey];
 		        return array( $toolbox->getRedbean(), $toolbox->getDatabaseAdapter(), $toolbox->getWriter(), $toolbox );
 		} else {
 			return Facade::getExtractedToolbox();

--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -83,7 +83,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	public function getToolbox()
 	{
 		if ( Facade::$useBeanOODB ) {
-			return $toolbox = Facade::$toolboxes[$this->databaseKey];
+			return Facade::$toolboxes[$this->databaseKey];
 		} else {
 			return Facade::getToolBox();
 		}
@@ -128,7 +128,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	{
 		if ( Facade::$useBeanOODB ) {
 			$toolbox = Facade::$toolboxes[$this->databaseKey];
-		        return array( $toolbox->getRedbean(), $toolbox->getDatabaseAdapter(), $toolbox->getWriter(), $toolbox );
+			return array( $toolbox->getRedbean(), $toolbox->getDatabaseAdapter(), $toolbox->getWriter(), $toolbox );
 		} else {
 			return Facade::getExtractedToolbox();
 		}

--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -31,9 +31,9 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 * @var \Closure
 	 */
 	private static $factory = null;
-	
+
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $databaseKey = NULL;
 
@@ -63,7 +63,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	{
 		self::$factory = $factory;
 	}
-	
+
 	/**
 	 * Sets the name of the database to get specific toolbox if needed.
 	 *
@@ -82,11 +82,10 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 */
 	public function getToolbox()
 	{
-		if ( Facade::$useBeanOODB ) {
+		if ( Facade::$useBeanOODB )
 			return Facade::$toolboxes[$this->databaseKey];
-		} else {
-			return Facade::getToolBox();
-		}
+
+		return Facade::getToolBox();
 	}
 
 	/**
@@ -129,8 +128,8 @@ class SimpleFacadeBeanHelper implements BeanHelper
 		if ( Facade::$useBeanOODB ) {
 			$toolbox = Facade::$toolboxes[$this->databaseKey];
 			return array( $toolbox->getRedbean(), $toolbox->getDatabaseAdapter(), $toolbox->getWriter(), $toolbox );
-		} else {
-			return Facade::getExtractedToolbox();
 		}
+
+		return Facade::getExtractedToolbox();
 	}
 }

--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -74,7 +74,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 */
 	public function __construct( $databaseKey = 'default' )
 	{
-		$this->database = $databaseKey;
+		$this->databaseKey = $databaseKey;
 	}
 
 	/**

--- a/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
+++ b/RedBeanPHP/BeanHelper/SimpleFacadeBeanHelper.php
@@ -72,7 +72,7 @@ class SimpleFacadeBeanHelper implements BeanHelper
 	 *
 	 * @return void
 	 */
-	public function __construct( $databaseKey )
+	public function __construct( $databaseKey = 'default' )
 	{
 		$this->database = $databaseKey;
 	}

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -68,7 +68,7 @@ class Facade
 	 * @var DBAdapter
 	 */
 	private static $adapter;
-	
+
 	/**
 	 * @var AssociationManager
 	 */
@@ -123,7 +123,7 @@ class Facade
 	 * @var array
 	 */
 	public static $toolboxes = array();
-	
+
 	/**
 	 * @var bool
 	 */
@@ -530,11 +530,10 @@ class Facade
 	 */
 	public static function store( $bean )
 	{
-		if (self::$useBeanOODB) {
+		if (self::$useBeanOODB)
 			return $bean->getBeanHelper()->getToolbox()->getRedBean()->store( $bean );
-		} else {
-			return self::$redbean->store( $bean );
-		}
+
+		return self::$redbean->store( $bean );
 	}
 
 	/**
@@ -680,11 +679,10 @@ class Facade
 	public static function trash( $beanOrType, $id = NULL )
 	{
 		if ( is_string( $beanOrType ) ) return self::trash( self::load( $beanOrType, $id ) );
-		if ( self::$useBeanOODB ) {
+		if ( self::$useBeanOODB )
 			return $beanOrType->getBeanHelper()->getToolbox()->getRedBean()->trash( $beanOrType );
-		} else {
-			return self::$redbean->trash( $beanOrType );
-		}
+
+		return self::$redbean->trash( $beanOrType );
 	}
 
 	/**
@@ -1357,11 +1355,10 @@ class Facade
 	 */
 	public static function hasTag( OODBBean $bean, $tags, $all = FALSE )
 	{
-		if (self::$useBeanOODB) {
+		if (self::$useBeanOODB)
 			return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->hasTag( $bean, $tags, $all );
-		} else {
-			return self::$redbean->getTagManager()->hasTag( $bean, $tags, $all );
-		}
+
+		return self::$redbean->getTagManager()->hasTag( $bean, $tags, $all );
 	}
 
 	/**
@@ -1420,11 +1417,10 @@ class Facade
 	 */
 	public static function tag( OODBBean $bean, $tagList = NULL )
 	{
-		if (self::$useBeanOODB) {
+		if (self::$useBeanOODB)
 			return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->tag( $bean, $tagList );
-		} else {
-			return self::$redbean->getTagManager()->tag( $bean, $tagList );
-		}
+
+		return self::$redbean->getTagManager()->tag( $bean, $tagList );
 	}
 
 	/**

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1186,7 +1186,7 @@ class Facade
 	public static function dup( $bean, $trail = array(), $pid = FALSE, $filters = array() )
 	{
 		if ( self::$useBeanOODB ) {
-			$duplicationManager = self::$bean->getBeanHelper()->getToolbox()->getRedBean()->getDuplicationManager();
+			$duplicationManager = $bean->getBeanHelper()->getToolbox()->getRedBean()->getDuplicationManager();
 		} else {
 			$duplicationManager = self::$redbean->getDuplicationManager();
 		}

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -68,6 +68,21 @@ class Facade
 	 * @var DBAdapter
 	 */
 	private static $adapter;
+	
+	/**
+	 * @var AssociationManager
+	 */
+	private static $associationManager;
+
+	/**
+	 * @var TagManager
+	 */
+	private static $tagManager;
+
+	/**
+	 * @var DuplicationManager
+	 */
+	private static $duplicationManager;
 
 	/**
 	 * @var LabelMaker
@@ -1554,13 +1569,30 @@ class Facade
 		self::$adapter            = self::$toolbox->getDatabaseAdapter();
 		self::$redbean            = self::$toolbox->getRedBean();
 		self::$finder             = new Finder( self::$toolbox );
-		self::$redbean->setAssociationManager( new AssociationManager( self::$toolbox ); );
+		try {
+			self::$associationManager = self::$redbean->getAssociationManager();
+		} catch ( RedException $e ) {
+			self::$associationManager = new AssociationManager( self::$toolbox );
+			self::$redbean->setAssociationManager( self::$associationManager );;
+		}
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );
-		self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper( self::$currentDB ) );
-		self::$redbean->setDuplicationManager( new DuplicationManager( self::$toolbox ) );
-		self::$redbean->setTagManager( new TagManager( self::$toolbox ) );
+		if ( self::$redbean->getBeanHelper() == NULL ) {
+			self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper( self::$currentDB ) );
+		}
+		try {
+			self::$duplicationManager = self::$redbean->getDuplicationManager();
+		} catch ( RedException $e ) {
+			self::$duplicationManager = new DuplicationManager( self::$toolbox );
+			self::$redbean->setDuplicationManager( self::$duplicationManager );
+		}
+		try {
+			self::$tagManager = self::$redbean->getTagManager();
+		} catch ( RedException $e ) {
+			self::$tagManager         = new TagManager( self::$toolbox );
+			self::$redbean->setTagManager( self::$tagManager );
+		}
 		return $oldTools;
 	}
 

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -2558,7 +2558,7 @@ class Facade
 	 */
 	public static function useBeanOODB( $toggle = TRUE )
 	{
-		self::$useBeanOODB = $automatic;
+		self::$useBeanOODB = $toggle;
 	}
 
 	/**

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -392,8 +392,8 @@ class Facade
 			throw new RedException( 'Database not found in registry. Add database using R::addDatabase().' );
 		}
 
-		self::configureFacadeWithToolbox( self::$toolboxes[$key] );
 		self::$currentDB = $key;
+		self::configureFacadeWithToolbox( self::$toolboxes[$key] );
 
 		return TRUE;
 	}
@@ -1558,7 +1558,7 @@ class Facade
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );
-		self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
+		self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper( self::$currentDB ) );
 		self::$redbean->setDuplicationManager( new DuplicationManager( self::$toolbox ) );
 		self::$redbean->setTagManager( new TagManager( self::$toolbox ) );
 		return $oldTools;

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -75,11 +75,6 @@ class Facade
 	private static $associationManager;
 
 	/**
-	 * @var TagManager
-	 */
-	private static $tagManager;
-
-	/**
 	 * @var LabelMaker
 	 */
 	private static $labelMaker;
@@ -1346,9 +1341,9 @@ class Facade
 	 *
 	 * @return boolean
 	 */
-	public static function hasTag( $bean, $tags, $all = FALSE )
+	public static function hasTag( OODBBean $bean, $tags, $all = FALSE )
 	{
-		return self::$tagManager->hasTag( $bean, $tags, $all );
+		return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->hasTag( $bean, $tags, $all );
 	}
 
 	/**
@@ -1372,9 +1367,9 @@ class Facade
 	 *
 	 * @return void
 	 */
-	public static function untag( $bean, $tagList )
+	public static function untag( OODBBean $bean, $tagList )
 	{
-		self::$tagManager->untag( $bean, $tagList );
+		$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->untag( $bean, $tagList );
 	}
 
 	/**
@@ -1403,7 +1398,7 @@ class Facade
 	 */
 	public static function tag( OODBBean $bean, $tagList = NULL )
 	{
-		return self::$tagManager->tag( $bean, $tagList );
+		return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->tag( $bean, $tagList );
 	}
 
 	/**
@@ -1428,7 +1423,7 @@ class Facade
 	 */
 	public static function addTags( OODBBean $bean, $tagList )
 	{
-		self::$tagManager->addTags( $bean, $tagList );
+		$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->addTags( $bean, $tagList );
 	}
 
 	/**
@@ -1462,7 +1457,7 @@ class Facade
 	 */
 	public static function tagged( $beanType, $tagList, $sql = '', $bindings = array() )
 	{
-		return self::$tagManager->tagged( $beanType, $tagList, $sql, $bindings );
+		return self::$redbean->getTagManager()->tagged( $beanType, $tagList, $sql, $bindings );
 	}
 
 	/**
@@ -1496,7 +1491,7 @@ class Facade
 	 */
 	public static function taggedAll( $beanType, $tagList, $sql = '', $bindings = array() )
 	{
-		return self::$tagManager->taggedAll( $beanType, $tagList, $sql, $bindings );
+		return self::$redbean->getTagManager()->taggedAll( $beanType, $tagList, $sql, $bindings );
 	}
 
 	/**
@@ -1551,7 +1546,7 @@ class Facade
 		$helper->attachEventListeners( self::$redbean );
 		self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
 		self::$redbean->setDuplicationManager( new DuplicationManager( self::$toolbox ) );
-		self::$tagManager         = new TagManager( self::$toolbox );
+		self::$redbean->setTagManager( new TagManager( self::$toolbox ) );
 		return $oldTools;
 	}
 

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -127,7 +127,7 @@ class Facade
 	/**
 	 * @var bool
 	 */
-	private static $useBeanOODB = FALSE;
+	public static $useBeanOODB = FALSE;
 
 	/**
 	 * Internal Query function, executes the desired query. Used by

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -70,11 +70,6 @@ class Facade
 	private static $adapter;
 
 	/**
-	 * @var AssociationManager
-	 */
-	private static $associationManager;
-
-	/**
 	 * @var LabelMaker
 	 */
 	private static $labelMaker;
@@ -1539,8 +1534,7 @@ class Facade
 		self::$adapter            = self::$toolbox->getDatabaseAdapter();
 		self::$redbean            = self::$toolbox->getRedBean();
 		self::$finder             = new Finder( self::$toolbox );
-		self::$associationManager = new AssociationManager( self::$toolbox );
-		self::$redbean->setAssociationManager( self::$associationManager );
+		self::$redbean->setAssociationManager( new AssociationManager( self::$toolbox ); );
 		self::$labelMaker         = new LabelMaker( self::$toolbox );
 		$helper                   = new SimpleModelHelper();
 		$helper->attachEventListeners( self::$redbean );

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1170,7 +1170,11 @@ class Facade
 	 */
 	public static function dup( $bean, $trail = array(), $pid = FALSE, $filters = array() )
 	{
-		$duplicationManager = self::$redbean->getDuplicationManager();
+		if ( self::$useBeanOODB ) {
+			$duplicationManager = self::$bean->getBeanHelper()->getToolbox()->getRedBean()->getDuplicationManager();
+		} else {
+			$duplicationManager = self::$redbean->getDuplicationManager();
+		}
 		$duplicationManager->setFilters( $filters );
 		return $duplicationManager->dup( $bean, $trail, $pid );
 	}
@@ -1338,7 +1342,11 @@ class Facade
 	 */
 	public static function hasTag( OODBBean $bean, $tags, $all = FALSE )
 	{
-		return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->hasTag( $bean, $tags, $all );
+		if (self::$useBeanOODB) {
+			return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->hasTag( $bean, $tags, $all );
+		} else {
+			return self::$redbean->getTagManager()->hasTag( $bean, $tags, $all );
+		}
 	}
 
 	/**
@@ -1364,7 +1372,11 @@ class Facade
 	 */
 	public static function untag( OODBBean $bean, $tagList )
 	{
-		$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->untag( $bean, $tagList );
+		if (self::$useBeanOODB) {
+			$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->untag( $bean, $tagList );
+		} else {
+			self::$redbean->getTagManager()->untag( $bean, $tagList );
+		}
 	}
 
 	/**
@@ -1393,7 +1405,11 @@ class Facade
 	 */
 	public static function tag( OODBBean $bean, $tagList = NULL )
 	{
-		return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->tag( $bean, $tagList );
+		if (self::$useBeanOODB) {
+			return $bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->tag( $bean, $tagList );
+		} else {
+			return self::$redbean->getTagManager()->tag( $bean, $tagList );
+		}
 	}
 
 	/**
@@ -1418,7 +1434,11 @@ class Facade
 	 */
 	public static function addTags( OODBBean $bean, $tagList )
 	{
-		$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->addTags( $bean, $tagList );
+		if (self::$useBeanOODB) {
+			$bean->getBeanHelper()->getToolbox()->getRedBean()->getTagManager()->addTags( $bean, $tagList );
+		} else {
+			self::$redbean->getTagManager()->addTags( $bean, $tagList );
+		}
 	}
 
 	/**

--- a/RedBeanPHP/OODB.php
+++ b/RedBeanPHP/OODB.php
@@ -68,11 +68,16 @@ class OODB extends Observable
 	 * @var AssociationManager
 	 */
 	protected $assocManager = NULL;
-	
+
 	/**
 	 * @var DuplicationManager
 	 */
 	protected $duplicationManager = NULL;
+
+	/**
+	 * @var TagManager
+	 */
+	protected $tagManager = NULL;
 
 	/**
 	 * @var Repository
@@ -532,7 +537,7 @@ class OODB extends Observable
 	{
 		$this->assocManager = $assocManager;
 	}
-	
+
 	/**
 	 * Returns the Duplication Manager for use with OODB.
 	 * A simple getter function to obtain a reference.
@@ -559,6 +564,34 @@ class OODB extends Observable
 	public function setDuplicationManager( DuplicationManager $duplicationManager )
 	{
 		$this->duplicationManager = $duplicationManager;
+	}
+
+	/**
+	 * Returns the Tag Manager for use with OODB.
+	 * A simple getter function to obtain a reference.
+	 *
+	 * @return TagManager
+	 */
+	public function getTagManager()
+	{
+		if ( !isset( $this->tagManager ) ) {
+			throw new RedException( 'No tag manager available.' );
+		}
+
+		return $this->tagManager;
+	}
+
+	/**
+	 * Sets the tag manager instance to be used by this OODB.
+	 * A simple setter function to set the tag manager.
+	 *
+	 * @param TagManager $tagManager sets the tag manager to be used
+	 *
+	 * @return void
+	 */
+	public function setTagManager( TagManager $tagManager )
+	{
+		$this->tagManager = $tagManager;
 	}
 
 	/**

--- a/RedBeanPHP/OODB.php
+++ b/RedBeanPHP/OODB.php
@@ -68,6 +68,11 @@ class OODB extends Observable
 	 * @var AssociationManager
 	 */
 	protected $assocManager = NULL;
+	
+	/**
+	 * @var DuplicationManager
+	 */
+	protected $duplicationManager = NULL;
 
 	/**
 	 * @var Repository
@@ -526,6 +531,34 @@ class OODB extends Observable
 	public function setAssociationManager( AssociationManager $assocManager )
 	{
 		$this->assocManager = $assocManager;
+	}
+	
+	/**
+	 * Returns the Duplication Manager for use with OODB.
+	 * A simple getter function to obtain a reference.
+	 *
+	 * @return DuplicationManager
+	 */
+	public function getDuplicationManager()
+	{
+		if ( !isset( $this->duplicationManager ) ) {
+			throw new RedException( 'No duplication manager available.' );
+		}
+
+		return $this->duplicationManager;
+	}
+
+	/**
+	 * Sets the duplication manager instance to be used by this OODB.
+	 * A simple setter function to set the duplication manager.
+	 *
+	 * @param DuplicationManager $duplicationManager sets the duplication manager to be used
+	 *
+	 * @return void
+	 */
+	public function setDuplicationManager( DuplicationManager $duplicationManager )
+	{
+		$this->duplicationManager = $duplicationManager;
 	}
 
 	/**

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -504,7 +504,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 	 *
 	 * @return BeanHelper
 	 */
-	public function getBeanHelper( BeanHelper $helper )
+	public function getBeanHelper()
 	{
 		return $this->beanHelper;
 	}

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -500,6 +500,16 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 	}
 
 	/**
+	 * Returns the Bean Helper for this bean.
+	 *
+	 * @return BeanHelper
+	 */
+	public function getBeanHelper( BeanHelper $helper )
+	{
+		return $this->beanHelper;
+	}
+
+	/**
 	 * Returns an ArrayIterator so you can treat the bean like
 	 * an array with the properties container as its contents.
 	 * This method is meant for PHP and allows you to access beans as if


### PR DESCRIPTION
The whole point of this commit is to have each bean remember, once dispensed/found/loaded, which OODB they belong to so that we can get their relations or store/trash them without having to switch database each time. This is related to #629.

It may be a bad idea, it may be badly implemented, and it will surely fail some tests which I'll fix.

Anyway, this does the following:

- Moves the Tag and Duplication managers inside the OODB object instead of the facade (with getters and setters for each)
- Adds an option (because BC) to use each bean's OODB instead of the currently selected one when storing, trashing, duplicating, and such, using R::setUseBeanOODB( TRUE ). _Don't like the name of this option, but it'll do for now_
- In order for the previous bullet to work, it adds a new public function to OODBBean : getBeanHelper()
- The SimpleFacadeBeanHelper now has a __construct and its getToolbox() and getExtractedToolbox() functions have been modified to return the correct toolbox if the option is used.


I'm not sure about how I did this. Maybe we should move the manager (Assoc, Tag and Dup) directly in the Toolbox.

I at least hope we can start a discussion on this, because I think it would be some neat feature to have.

Lyn.