### PR TITLE
Move finder, managers and helpers to toolbox

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -95,6 +95,16 @@ class Facade
 	private static $finder;
 
 	/**
+	 * @var SimpleModelHelper
+	 */
+	private static $simpleModelHelper;
+
+	/**
+	 * @var beanHelper
+	 */
+	private static $beanHelper;
+
+	/**
 	 * @var Logger
 	 */
 	private static $logger;
@@ -1534,17 +1544,34 @@ class Facade
 		self::$writer             = self::$toolbox->getWriter();
 		self::$adapter            = self::$toolbox->getDatabaseAdapter();
 		self::$redbean            = self::$toolbox->getRedBean();
-		self::$finder             = new Finder( self::$toolbox );
-		self::$associationManager = new AssociationManager( self::$toolbox );
-		self::$redbean->setAssociationManager( self::$associationManager );
-		self::$labelMaker         = new LabelMaker( self::$toolbox );
-		$helper                   = new SimpleModelHelper();
-		$helper->attachEventListeners( self::$redbean );
-		if (self::$redbean->getBeanHelper() == NULL) {
-			self::$redbean->setBeanHelper( new SimpleFacadeBeanHelper );
+
+		if ( ( self::$finder = self::$toolbox->getFinder() ) === NULL ) {
+			self::$finder = self::$toolbox->setFinder( new Finder( self::$toolbox ) );
 		}
-		self::$duplicationManager = new DuplicationManager( self::$toolbox );
-		self::$tagManager         = new TagManager( self::$toolbox );
+
+		if ( ( self::$associationManager = self::$toolbox->getAssociationManager() ) === NULL ) {
+			self::$associationManager = self::$toolbox->setAssociationManager( new AssociationManager( self::$toolbox ) );
+		}
+
+		if ( ( self::$labelMaker = self::$toolbox->getLabelMaker() ) === NULL ) {
+			self::$labelMaker = self::$toolbox->setLabelMaker( new LabelMaker( self::$toolbox ) );
+		}
+
+		if ( ( self::$simpleModelHelper = self::$toolbox->getSimpleModelHelper() ) === NULL ) {
+			self::$simpleModelHelper = self::$toolbox->setSimpleModelHelper( new SimpleModelHelper( self::$toolbox ) );
+		}
+
+		if ( ( self::$beanHelper = self::$toolbox->getBeanHelper() ) === NULL ) {
+			self::$beanHelper = self::$toolbox->setBeanHelper( new SimpleFacadeBeanHelper( self::$toolbox ) );
+		}
+
+		if ( ( self::$duplicationManager = self::$toolbox->getDuplicationManager() ) === NULL ) {
+			self::$duplicationManager = self::$toolbox->setDuplicationManager( new DuplicationManager( self::$toolbox ) );
+		}
+
+		if ( ( self::$tagManager = self::$toolbox->getTagManager() ) === NULL ) {
+			self::$tagManager = self::$toolbox->setTagManager( new TagManager( self::$toolbox ) );
+		}
 		return $oldTools;
 	}
 

--- a/RedBeanPHP/ToolBox.php
+++ b/RedBeanPHP/ToolBox.php
@@ -106,9 +106,16 @@ class ToolBox
 	 */
 	public function __construct( OODB $oodb, Adapter $adapter, QueryWriter $writer )
 	{
-		$this->oodb    = $oodb;
-		$this->adapter = $adapter;
-		$this->writer  = $writer;
+		$this->oodb               = $oodb;
+		$this->adapter            = $adapter;
+		$this->writer             = $writer;
+		$this->finder             = NULL;
+		$this->associationManger  = NULL;
+		$this->labelMaker         = NULL;
+		$this->simpleModelHelper  = NULL;
+		$this->beanHelper         = NULL;
+		$this->duplicationManager = NULL;
+		$this->tagManager         = NULL;
 		return $this;
 	}
 
@@ -201,11 +208,12 @@ class ToolBox
 	}
 	
 	/**
-	 * Sets the finder.
+	 * Sets and returns the finder.
 	 */
 	public function setFinder( Finder $finder )
 	{
 		$this->finder = $finder;
+		return $this->finder;
 	}
 
 	/**
@@ -217,11 +225,13 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the association manager.
+	 * Sets and returns the association manager.
 	 */
 	public function setAssociationManager( AssociationManager $associationManager )
 	{
 		$this->associationManager = $associationManager;
+		$this->oodb->setAssociationManager( $associationManager );
+		return $this->associationManager;
 	}
 
 	/**
@@ -233,11 +243,12 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the label maker.
+	 * Sets and returns the label maker.
 	 */
 	public function setLabelMaker( LabelMaker $labelMaker )
 	{
 		$this->labelMaker = $labelMaker;
+		return $this->labelMaker;
 	}
 
 	/**
@@ -249,11 +260,13 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the simple model helper.
+	 * Sets and returns the simple model helper.
 	 */
 	public function setSimpleModelHelper( SimpleModelHelper $simpleModelHelper )
 	{
 		$this->simpleModelHelper = $simpleModelHelper;
+		$this->simpleModelHelper->attachEventListeners( $this->oodb );
+		return $this->simpleModelHelper;
 	}
 
 	/**
@@ -265,11 +278,13 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the bean helper.
+	 * Sets and returns the bean helper.
 	 */
 	public function setBeanHelper( BeanHelper $beanHelper )
 	{
 		$this->beanHelper = $beanHelper;
+		$this->oodb->setBeanHelper( $beanHelper );
+		return $this->beanHelper;
 	}
 
 	/**
@@ -281,11 +296,12 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the duplication manager.
+	 * Sets and returns the duplication manager.
 	 */
 	public function setDuplicationManager( DuplicationManager $duplicationManager )
 	{
 		$this->duplicationManager = $duplicationManager;
+		return $this->duplicationManager;
 	}
 
 	/**
@@ -297,11 +313,12 @@ class ToolBox
 	}
 
 	/**
-	 * Sets the tag manager.
+	 * Sets and returns the tag manager.
 	 */
 	public function setTagManager( TagManager $tagManager )
 	{
 		$this->tagManager = $tagManager;
+		return $this->tagManager;
 	}
 
 	/**

--- a/RedBeanPHP/ToolBox.php
+++ b/RedBeanPHP/ToolBox.php
@@ -43,6 +43,41 @@ class ToolBox
 	protected $adapter;
 
 	/**
+	 * @var Finder
+	 */
+	protected $finder;
+
+	/**
+	 * @var AssociationManager
+	 */
+	protected $associationManager;
+
+	/**
+	 * @var LabelMaker
+	 */
+	protected $labelMaker;
+
+	/**
+	 * @var SimpleModelHelper
+	 */
+	protected $simpleModelHelper;
+
+	/**
+	 * @var BeanHelper
+	 */
+	protected $beanHelper;
+
+	/**
+	 * @var DuplicationManager
+	 */
+	protected $duplicationManager;
+
+	/**
+	 * @var TagManager
+	 */
+	protected $tagManager;
+
+	/**
 	 * Constructor.
 	 * The toolbox is an integral part of RedBeanPHP providing the basic
 	 * architectural building blocks to manager objects, helpers and additional tools
@@ -163,5 +198,117 @@ class ToolBox
 	public function getDatabaseAdapter()
 	{
 		return $this->adapter;
+	}
+	
+	/**
+	 * Sets the finder.
+	 */
+	public function setFinder( Finder $finder )
+	{
+		$this->finder = $finder;
+	}
+
+	/**
+	 * Returns the finder.
+	 */
+	public function getFinder()
+	{
+		return $this->finder;
+	}
+
+	/**
+	 * Sets the association manager.
+	 */
+	public function setAssociationManager( AssociationManager $associationManager )
+	{
+		$this->associationManager = $associationManager;
+	}
+
+	/**
+	 * Returns the association manager.
+	 */
+	public function getAssociationManager()
+	{
+		return $this->associationManager;
+	}
+
+	/**
+	 * Sets the label maker.
+	 */
+	public function setLabelMaker( LabelMaker $labelMaker )
+	{
+		$this->labelMaker = $labelMaker;
+	}
+
+	/**
+	 * Returns the label maker.
+	 */
+	public function getLabelMaker()
+	{
+		return $this->labelMaker;
+	}
+
+	/**
+	 * Sets the simple model helper.
+	 */
+	public function setSimpleModelHelper( SimpleModelHelper $simpleModelHelper )
+	{
+		$this->simpleModelHelper = $simpleModelHelper;
+	}
+
+	/**
+	 * Returns the simple model helper.
+	 */
+	public function getSimpleModelHelper()
+	{
+		return $this->simpleModelHelper;
+	}
+
+	/**
+	 * Sets the bean helper.
+	 */
+	public function setBeanHelper( BeanHelper $beanHelper )
+	{
+		$this->beanHelper = $beanHelper;
+	}
+
+	/**
+	 * Returns the bean helper.
+	 */
+	public function getBeanHelper()
+	{
+		return $this->beanHelper;
+	}
+
+	/**
+	 * Sets the duplication manager.
+	 */
+	public function setDuplicationManager( DuplicationManager $duplicationManager )
+	{
+		$this->duplicationManager = $duplicationManager;
+	}
+
+	/**
+	 * Returns the duplicationManager.
+	 */
+	public function getDuplicationManager()
+	{
+		return $this->duplicationManager;
+	}
+
+	/**
+	 * Sets the tag manager.
+	 */
+	public function setTagManager( TagManager $tagManager )
+	{
+		$this->tagManager = $tagManager;
+	}
+
+	/**
+	 * Returns the tag manager.
+	 */
+	public function getTagManager()
+	{
+		return $this->tagManager;
 	}
 }


### PR DESCRIPTION
As stated this moves everything to the toolbox but doesn't touch anything else (stuff is still accessible from Facade or OODB as it was before).

This allows to tweak configureFacadeWithToolbox() so that it doesn't create new objects and stuff everytime I change database with selectDatabase().

~Tests are fine on PHP7, will see what Travis as to say~.