### PR TITLE
Add a reset() function to BeanCollection

### DIFF
--- a/RedBeanPHP/BeanCollection.php
+++ b/RedBeanPHP/BeanCollection.php
@@ -78,6 +78,16 @@ class BeanCollection
 		}
 		return NULL;
 	}
+	
+	/**
+	 * Resets the collection from the start, like a fresh() on a bean.
+	 *
+	 * @return void
+	 */
+	public function reset()
+	{
+		$this->cursor->reset();
+	}
 
 	/**
 	 * Closes the underlying cursor (needed for some databases).

--- a/RedBeanPHP/Cursor.php
+++ b/RedBeanPHP/Cursor.php
@@ -29,6 +29,14 @@ interface Cursor
 	 * @return array
 	 */
 	public function getNextItem();
+	
+	/**
+	 * Resets the cursor by closing it and re-executing the statement.
+	 * This reloads fresh data from the database for the whole collection.
+	 *
+	 * @return void
+	 */
+	public function reset();
 
 	/**
 	 * Closes the database cursor.

--- a/RedBeanPHP/Cursor/NullCursor.php
+++ b/RedBeanPHP/Cursor/NullCursor.php
@@ -29,6 +29,14 @@ class NullCursor implements Cursor
 	{
 		return NULL;
 	}
+	
+	/**
+	 * @see Cursor::reset
+	 */
+	public function reset()
+	{
+		return NULL;
+	}
 
 	/**
 	 * @see Cursor::close

--- a/RedBeanPHP/Cursor/PDOCursor.php
+++ b/RedBeanPHP/Cursor/PDOCursor.php
@@ -54,6 +54,15 @@ class PDOCursor implements Cursor
 	{
 		return $this->res->fetch();
 	}
+	
+	/**
+	 * @see Cursor::reset
+	 */
+	public function reset()
+	{
+		$this->close();
+		$this->res->execute();
+	}
 
 	/**
 	 * @see Cursor::close


### PR DESCRIPTION
This PR allows to call `reset()` on a BeanCollection, fetching data again from the database and putting the cursor back to the first position.

Exemple:

```php
// Let's say we have a table "book" with 5 books named book1, book2, ...

// Get every books in a collection
$collection = R::findCollection( 'book' );

// Print books' names
print $collection->next()->name; // 'book1'
print $collection->next()->name; // 'book2'

// Change the 3rd book's name
$book3 = R::load( 'book', 3 );
$book3->name = 'notBook3';
R::store( $book3 );

// It isn't reflected because collection data as already been loaded
print $collection->next()->name; // 'book3'

// This fetches data from the database again and puts the cursor back at the start
$collection->reset();
// It's the same as doing this again
// $collection = R::findCollection( 'book' );
// But it's faster as it leverages a lot of the code by using what it already has

// Let's print those names again
print $collection->next()->name; // 'book1'
print $collection->next()->name; // 'book2'
print $collection->next()->name; // 'notBook3'
```