### PR TITLE
Update queryRecordWithCursor

### DIFF
--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -931,9 +931,18 @@ abstract class AQueryWriter
 	 */
 	public function queryRecordWithCursor( $type, $addSql = NULL, $bindings = array() )
 	{
-		$sql = $this->glueSQLCondition( $addSql, NULL );
 		$table = $this->esc( $type );
-		$sql   = "SELECT {$table}.* FROM {$table} {$sql}";
+
+		$sqlFilterStr = '';
+		if ( count( self::$sqlFilters ) ) {
+			$sqlFilterStr = $this->getSQLFilterSnippet( $type );
+		}
+
+		$fieldSelection = ( self::$flagNarrowFieldMode ) ? "{$table}.*" : '*';
+
+		$sql = $this->glueSQLCondition( $addSql, NULL );
+		$sql = "SELECT {$fieldSelection} {$sqlFilterStr} FROM {$table} {$sql} -- keep-cache";
+
 		return $this->adapter->getCursor( $sql, $bindings );
 	}
 


### PR DESCRIPTION
This PR adds the following features/modifications to queryRecordWithCursor (used to find collections):
- Adds flagNarrowFieldMode
- Allows the use of sqlFilters (because why not ?)
- And prevent it from breaking cache state (it's only a SELECT)