### PR TITLE
Automatically trim types in findMulti()

### DIFF
--- a/RedBeanPHP/Finder.php
+++ b/RedBeanPHP/Finder.php
@@ -316,7 +316,7 @@ class Finder
 	 */
 	public function findMulti( $types, $sql, $bindings = array(), $remappings = array(), $queryTemplate = ' %s.%s AS %s__%s' )
 	{
-		if ( !is_array( $types ) ) $types = explode( ',', $types );
+		if ( !is_array( $types ) ) $types = array_map( 'trim', explode( ',', $types ) );
 		if ( !is_array( $sql ) ) {
 			$writer = $this->toolbox->getWriter();
 			$adapter = $this->toolbox->getDatabaseAdapter();


### PR DESCRIPTION
It's a small quality of life feature that doesn't affect performance, so why not ? :)