### PR TITLE
Make $sql optional for findMulti()

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -966,13 +966,13 @@ class Facade
 	 * @note instead of an SQL query you can pass a result array as well.
 	 *
 	 * @param string|array $types         a list of types (either array or comma separated string)
-	 * @param string|array $sql           an SQL query or an array of prefetched records
+	 * @param string|array $sql           optional, an SQL query or an array of prefetched records
 	 * @param array        $bindings      optional, bindings for SQL query
 	 * @param array        $remappings    optional, an array of remapping arrays
 	 *
 	 * @return array
 	 */
-	public static function findMulti( $types, $sql, $bindings = array(), $remappings = array() )
+	public static function findMulti( $types, $sql = NULL, $bindings = array(), $remappings = array() )
 	{
 		return self::$finder->findMulti( $types, $sql, $bindings, $remappings );
 	}


### PR DESCRIPTION
_The preview is ugly, I only added like 8 lines of code for info._

So this allows to do stuff like
```php
R::findMulti( 'this,that' );
```
which is an alias for
```php
R::findMulti( 'this,that', 'SELECT this.*, that.* FROM this, that' );
```
but much faster since it directly uses Finder::find() instead of parsing the SQL and all.

It is still affected by remappings if there are any.