### PR TITLE
Manually define bindings parameters type

### DIFF
--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -117,9 +117,12 @@ class RPDO implements Driver
 	{
 		foreach ( $bindings as $key => &$value ) {
 			$k = is_integer( $key ) ? $key + 1 : $key;
+
 			if ( is_array( $value ) && count( $value ) == 2 ) {
 				$paramType = end( $value );
 				$value = reset( $value );
+			} else {
+				$paramType = NULL;
 			}
 
 			if ( is_null( $value ) ) {
@@ -127,7 +130,7 @@ class RPDO implements Driver
 				continue;
 			}
 
-			if ( !isset( $paramType ) || ( $paramType != \PDO::PARAM_INT && $paramType != \PDO::PARAM_STR ) ) {
+			if ( $paramType != \PDO::PARAM_INT && $paramType != \PDO::PARAM_STR ) {
 				if ( !$this->flagUseStringOnlyBinding && AQueryWriter::canBeTreatedAsInt( $value ) && abs( $value ) <= $this->max ) {
 					$paramType = \PDO::PARAM_INT;
 				} else {

--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -116,23 +116,26 @@ class RPDO implements Driver
 	protected function bindParams( $statement, $bindings )
 	{
 		foreach ( $bindings as $key => &$value ) {
-			if ( is_integer( $key ) ) {
-				if ( is_null( $value ) ) {
-					$statement->bindValue( $key + 1, NULL, \PDO::PARAM_NULL );
-				} elseif ( !$this->flagUseStringOnlyBinding && AQueryWriter::canBeTreatedAsInt( $value ) && abs( $value ) <= $this->max ) {
-					$statement->bindParam( $key + 1, $value, \PDO::PARAM_INT );
-				} else {
-					$statement->bindParam( $key + 1, $value, \PDO::PARAM_STR );
-				}
-			} else {
-				if ( is_null( $value ) ) {
-					$statement->bindValue( $key, NULL, \PDO::PARAM_NULL );
-				} elseif ( !$this->flagUseStringOnlyBinding && AQueryWriter::canBeTreatedAsInt( $value ) && abs( $value ) <= $this->max ) {
-					$statement->bindParam( $key, $value, \PDO::PARAM_INT );
-				} else {
-					$statement->bindParam( $key, $value, \PDO::PARAM_STR );
-				}
+			$k = is_integer( $key ) ? $key + 1 : $key;
+			if ( is_array( $value ) && count( $value ) == 2) {
+				$paramType = end( $value );
+				$value = reset( $value );
 			}
+
+			if ( is_null( $value ) ) {
+				$statement->bindValue( $k, NULL, \PDO::PARAM_NULL );
+				continue;
+			}
+
+			if ( !isset( $paramType ) || ( $paramType != \PDO::PARAM_INT && $paramType != \PDO::PARAM_STR ) ) {
+				if ( !$this->flagUseStringOnlyBinding && AQueryWriter::canBeTreatedAsInt( $value ) && abs( $value ) <= $this->max ) {
+					$paramType = \PDO::PARAM_INT
+				} else {
+					$paramType = \PDO::PARAM_STR;
+				}
+			} 
+
+			$statement->bindParam( $k, $value, $paramType );
 		}
 	}
 

--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -117,7 +117,7 @@ class RPDO implements Driver
 	{
 		foreach ( $bindings as $key => &$value ) {
 			$k = is_integer( $key ) ? $key + 1 : $key;
-			if ( is_array( $value ) && count( $value ) == 2) {
+			if ( is_array( $value ) && count( $value ) == 2 ) {
 				$paramType = end( $value );
 				$value = reset( $value );
 			}
@@ -129,11 +129,11 @@ class RPDO implements Driver
 
 			if ( !isset( $paramType ) || ( $paramType != \PDO::PARAM_INT && $paramType != \PDO::PARAM_STR ) ) {
 				if ( !$this->flagUseStringOnlyBinding && AQueryWriter::canBeTreatedAsInt( $value ) && abs( $value ) <= $this->max ) {
-					$paramType = \PDO::PARAM_INT
+					$paramType = \PDO::PARAM_INT;
 				} else {
 					$paramType = \PDO::PARAM_STR;
 				}
-			} 
+			}
 
 			$statement->bindParam( $k, $value, $paramType );
 		}


### PR DESCRIPTION
This is just a mockup for #700 for us to discuss about.

The idea is to use it this way:
```php
$bean = R::findOne( 'bean', ' property = ? AND property2 = ? AND property3 = ? ', [
    $value,
    [ $value2, PDO::PARAM_INT ],
    [ $value3, PDO::PARAM_STR ]
]);
```
It should work anywhere we are able to pass $bindings as an argument without issue.

Pinging some people: @gabordemooij @brtdv @marios88 