### PR TITLE
Fix annotation for convertToBean() method

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1357,7 +1357,7 @@ class Facade
 	 * @param array  $row       one row from the database
 	 * @param string $metamask  metamask (see convertToBeans)
 	 *
-	 * @return RedBeanPHP\OODBBean
+	 * @return OODBBean
 	 */
 	public static function convertToBean( $type, $row, $metamask = NULL )
 	{


### PR DESCRIPTION
The method's @return annotation should be OODBean instead of RedBeanPHP\OODBean as it has been identified in the use statement at the top. Alternatively, \RedBeanPHP\OODBean could be used.