### PR TITLE
Refactore storeAll() to allow optimization in Fluid

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1862,11 +1862,7 @@ class Facade
 	 */
 	public static function storeAll( $beans )
 	{
-		$ids = array();
-		foreach ( $beans as $bean ) {
-			$ids[] = self::store( $bean );
-		}
-		return $ids;
+        return self::$redbean->storeAll( $beans );
 	}
 
 	/**

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1862,7 +1862,7 @@ class Facade
 	 */
 	public static function storeAll( $beans )
 	{
-        return self::$redbean->storeAll( $beans );
+		return self::$redbean->storeAll( $beans );
 	}
 
 	/**

--- a/RedBeanPHP/OODB.php
+++ b/RedBeanPHP/OODB.php
@@ -122,32 +122,32 @@ class OODB extends Observable
 		return $bean;
 	}
 
-    /**
-     * Unboxes an array of beans from a FUSE model if needed and checks whether the beans are
-     * instances of OODBBean.
-     *
-     * @param array $beans beans you wish to unbox
-     *
-     * @return array
-     */
-    protected function unboxAllIfNeeded( $beans )
-    {
-        $results = array();
+	/**
+	 * Unboxes an array of beans from a FUSE model if needed and checks whether the beans are
+	 * instances of OODBBean.
+	 *
+	 * @param array $beans beans you wish to unbox
+	 *
+	 * @return array
+	 */
+	protected function unboxAllIfNeeded( $beans )
+	{
+		$results = array();
 
-        foreach ($beans as $bean) {
-            if ($bean instanceof SimpleModel) {
-                $bean = $bean->unbox();
-            }
-            if (!($bean instanceof OODBBean)) {
-                throw new RedException('OODB Store require only beans, got: ' . gettype($bean));
-            }
-            $results[] = $bean;
-        }
+		foreach ($beans as $bean) {
+			if ($bean instanceof SimpleModel) {
+				$bean = $bean->unbox();
+			}
+			if (!($bean instanceof OODBBean)) {
+				throw new RedException('OODB Store require only beans, got: ' . gettype($bean));
+			}
+			$results[] = $bean;
+		}
 
-        return $results;
-    }
+		return $results;
+	}
 
-    /**
+	/**
 	 * Constructor, requires a query writer.
 	 * Most of the time, you do not need to use this constructor,
 	 * since the facade takes care of constructing and wiring the
@@ -409,43 +409,43 @@ class OODB extends Observable
 	 */
 	public function store( $bean )
 	{
-	    $arr = $this->storeAll(array($bean));
-	    return reset($arr);
+		$arr = $this->storeAll(array($bean));
+		return reset($arr);
 	}
 
-    /**
-     * Stores an array of bean in the database. This method takes an array
-     * of OODBBean Bean Objects $beans and stores them
-     * in the database. If the database schema is not compatible
-     * with this bean and RedBean runs in fluid mode the schema
-     * will be altered to store the bean correctly.
-     * If the database schema is not compatible with this bean and
-     * RedBean runs in frozen mode it will throw an exception.
-     * This function returns the primary key ID of the inserted
-     * bean.
-     *
-     * The return value is an array of integers if possible. If it is not possible to
-     * represent the value as an integer a string element will be returned. We use
-     * explicit casts instead of functions to preserve performance
-     * (0.13 vs 0.28 for 10000 iterations on Core i3).
-     *
-     * @param array $beans beans to store
-     *
-     * @return array
-     */
-    public function storeAll( $beans )
-    {
-        $beans = $this->unboxAllIfNeeded( $beans );
-        $ids = $this->repository->storeAll( $beans );
-        if ( self::$autoClearHistoryAfterStore ) {
-            foreach ($beans as $bean) {
-                $bean->clearHistory();
-            }
-        }
-        return $ids;
-    }
+	/**
+	 * Stores an array of bean in the database. This method takes an array
+	 * of OODBBean Bean Objects $beans and stores them
+	 * in the database. If the database schema is not compatible
+	 * with this bean and RedBean runs in fluid mode the schema
+	 * will be altered to store the bean correctly.
+	 * If the database schema is not compatible with this bean and
+	 * RedBean runs in frozen mode it will throw an exception.
+	 * This function returns the primary key ID of the inserted
+	 * bean.
+	 *
+	 * The return value is an array of integers if possible. If it is not possible to
+	 * represent the value as an integer a string element will be returned. We use
+	 * explicit casts instead of functions to preserve performance
+	 * (0.13 vs 0.28 for 10000 iterations on Core i3).
+	 *
+	 * @param array $beans beans to store
+	 *
+	 * @return array
+	 */
+	public function storeAll( $beans )
+	{
+		$beans = $this->unboxAllIfNeeded( $beans );
+		$ids = $this->repository->storeAll( $beans );
+		if ( self::$autoClearHistoryAfterStore ) {
+			foreach ($beans as $bean) {
+				$bean->clearHistory();
+			}
+		}
+		return $ids;
+	}
 
-    /**
+	/**
 	 * Loads a bean from the object database.
 	 * It searches for a OODBBean Bean Object in the
 	 * database. It does not matter how this bean has been stored.

--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -118,7 +118,7 @@ abstract class Repository
 				}
 			}
 		}
-		$this->storeBean( $bean );
+		$this->storeCleanedBeans( array( $bean ) );
 		$this->processTrashcan( $bean, $ownTrashcan );
 		$this->processAdditions( $bean, $ownAdditions );
 		$this->processResidue( $ownresidue );
@@ -482,7 +482,7 @@ abstract class Repository
 		if ( $processLists ) {
 			$this->storeBeanWithLists( $bean );
 		} else {
-			$this->storeBean( $bean );
+			$this->storeCleanedBeans( array( $bean ) );
 		}
 		$this->oodb->signal( 'after_update', $bean );
 
@@ -531,7 +531,7 @@ abstract class Repository
 		}
 		unset($bean);
 
-		$this->storeAllBeans( $beans );
+		$this->storeCleanedBeans( $beans );
 
 		foreach ( $postProcessing as $arr ) {
 			$this->processTrashcan( $arr['bean'], $arr['ownTrashcan'] );

--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -489,7 +489,113 @@ abstract class Repository
 		return ( (string) $bean->id === (string) (int) $bean->id ) ? (int) $bean->id : (string) $bean->id;
 	}
 
-	/**
+	private function storeBeansThatMightHaveLists( $beans )
+    {
+        $postProcessing = array();
+        foreach ($beans as &$bean) {
+            $sharedAdditions = $sharedTrashcan = $sharedresidue = $sharedItems = $ownAdditions = $ownTrashcan = $ownresidue = $embeddedBeans = array(); //Define groups
+            foreach ( $bean as $property => $value ) {
+                $value = ( $value instanceof SimpleModel ) ? $value->unbox() : $value;
+                if ( $value instanceof OODBBean ) {
+                    $this->processEmbeddedBean( $embeddedBeans, $bean, $property, $value );
+                    $bean->setMeta("sys.typeof.{$property}", $value->getMeta('type'));
+                } elseif ( is_array( $value ) ) {
+                    foreach($value as &$item) {
+                        $item = ( $item instanceof SimpleModel ) ? $item->unbox() : $item;
+                    }
+                    $originals = $bean->moveMeta( 'sys.shadow.' . $property, array() );
+                    if ( strpos( $property, 'own' ) === 0 ) {
+                        list( $ownAdditions, $ownTrashcan, $ownresidue ) = $this->processGroups( $originals, $value, $ownAdditions, $ownTrashcan, $ownresidue );
+                        $listName = lcfirst( substr( $property, 3 ) );
+                        if ($bean->moveMeta( 'sys.exclusive-'.  $listName ) ) {
+                            OODBBean::setMetaAll( $ownTrashcan, 'sys.garbage', TRUE );
+                            OODBBean::setMetaAll( $ownAdditions, 'sys.buildcommand.fkdependson', $bean->getMeta( 'type' ) );
+                        }
+                        unset( $bean->$property );
+                    } elseif ( strpos( $property, 'shared' ) === 0 ) {
+                        list( $sharedAdditions, $sharedTrashcan, $sharedresidue ) = $this->processGroups( $originals, $value, $sharedAdditions, $sharedTrashcan, $sharedresidue );
+                        unset( $bean->$property );
+                    }
+                }
+            }
+
+            $postProcessing[] = array(
+                'bean' => $bean,
+                'sharedAdditions' => $sharedAdditions,
+                'sharedTrashcan' => $sharedTrashcan,
+                'sharedresidue' => $sharedresidue,
+                'ownAdditions' => $ownAdditions,
+                'ownTrashcan' => $ownTrashcan,
+                'ownresidue' => $ownresidue
+            );
+        }
+        unset($bean);
+
+        $this->storeAllBeans( $beans );
+
+        foreach ($postProcessing as $arr) {
+            $this->processTrashcan( $arr['bean'], $arr['ownTrashcan'] );
+            $this->processAdditions( $arr['bean'], $arr['ownAdditions'] );
+            $this->processResidue( $arr['ownresidue'] );
+            $this->processSharedTrashcan( $arr['bean'], $arr['sharedTrashcan'] );
+            $this->processSharedAdditions( $arr['bean'], $arr['sharedAdditions'] );
+            $this->processSharedResidue( $arr['bean'], $arr['sharedresidue'] );
+        }
+    }
+
+    /**
+     * Stores an array of beans in the database. This method takes an array
+     * of OODBBean Bean Objects $beans and stores it
+     * in the database. If the database schema is not compatible
+     * with this bean and RedBean runs in fluid mode the schema
+     * will be altered to store the bean correctly.
+     * If the database schema is not compatible with this bean and
+     * RedBean runs in frozen mode it will throw an exception.
+     * This function returns the primary key ID of the inserted
+     * bean.
+     *
+     * The return value is an integer if possible. If it is not possible to
+     * represent the value as an integer a string will be returned. We use
+     * explicit casts instead of functions to preserve performance
+     * (0.13 vs 0.28 for 10000 iterations on Core i3).
+     *
+     * @param array $beans beans to store
+     *
+     * @return array
+     */
+    public function storeAll( $beans )
+    {
+        $weHaveWorkToDo = false;
+        $ids = array();
+        foreach ($beans as $bean) {
+            $ids[] = $bean->getID();
+            $processLists = $this->hasListsOrObjects( $bean );
+            if ( $processLists || $bean->getMeta( 'tainted' ) ) {
+                $weHaveWorkToDo = true;
+            }
+        }
+        if (!$weHaveWorkToDo) {
+            return $ids;
+        }
+
+        // Send 'update' signals on all the beans
+        foreach ($beans as $bean) {
+            $this->oodb->signal('update', $bean);
+        }
+
+        $this->storeBeansThatMightHaveLists( $beans );
+
+        // Send 'after_update' signals on all the beans
+        $ids = array();
+        foreach ($beans as $bean) {
+            $this->oodb->signal( 'after_update', $bean );
+            $ids[] = ( (string) $bean->id === (string) (int) $bean->id ) ? (int) $bean->id : (string) $bean->id;
+        }
+
+        return $ids;
+    }
+
+    /**
 	 * Returns an array of beans. Pass a type and a series of ids and
 	 * this method will bring you the corresponding beans.
 	 *

--- a/RedBeanPHP/Repository/Fluid.php
+++ b/RedBeanPHP/Repository/Fluid.php
@@ -230,7 +230,81 @@ class Fluid extends Repository
 		$bean->setMeta( 'tainted', FALSE );
 	}
 
-	/**
+    /**
+     * Stores cleaned beans; i.e. only scalar values. This is the core of the store()
+     * method. When all lists and embedded beans (parent objects) have been processed and
+     * removed from the original bean the bean is passed to this method to be stored
+     * in the database.
+     *
+     * @param array $beans the clean beans
+     *
+     * @return void
+     */
+    protected function storeAllBeans( $beans )
+    {
+        $tables = array();
+        foreach ($beans as $bean) {
+            if ( $bean->getMeta( 'changed' ) ) {
+                $this->check($bean);
+                $table = $bean->getMeta('type');
+                $tables[$table] = 1;
+            }
+        }
+        $tables = array_keys($tables);
+
+        foreach ($tables as $table) {
+            // Do all schema changes for the table up front
+            $columnCache = NULL;
+            $alreadySeenBeanForThisTable = false;
+            foreach ($beans as $bean) {
+                if ( $bean->getMeta( 'changed' ) && $table == $bean->getMeta( 'type' ) ) {
+                    if ( !$alreadySeenBeanForThisTable ) {
+                        $this->createTableIfNotExists($bean, $table);
+                        $alreadySeenBeanForThisTable = true;
+                    }
+
+                    $partial = ( $this->partialBeans === TRUE || ( is_array( $this->partialBeans ) && in_array( $table, $this->partialBeans ) ) );
+                    if ( $partial ) {
+                        $mask = $bean->getMeta( 'changelist' );
+                        $bean->setMeta( 'changelist', array() );
+                    }
+
+                    foreach ( $bean as $property => $value ) {
+                        if ( $partial && !in_array( $property, $mask ) ) continue;
+                        if ( $property !== 'id' ) {
+                            $this->modifySchema( $bean, $property, $value, $columnCache );
+                        }
+                    }
+                }
+            }
+
+            // Now update the records
+            foreach ($beans as $bean) {
+                if ( $bean->getMeta( 'changed' ) && $table == $bean->getMeta( 'type' ) ) {
+                    $updateValues = array();
+
+                    $partial = ( $this->partialBeans === TRUE || ( is_array( $this->partialBeans ) && in_array( $table, $this->partialBeans ) ) );
+                    if ( $partial ) {
+                        $mask = $bean->getMeta( 'changelist' );
+                        $bean->setMeta( 'changelist', array() );
+                    }
+
+                    foreach ( $bean as $property => $value ) {
+                        if ( $partial && !in_array( $property, $mask ) ) continue;
+                        if ( $property !== 'id' ) {
+                            $updateValues[] = array( 'property' => $property, 'value' => $value );
+                        }
+                    }
+
+                    $bean->id = $this->writer->updateRecord( $table, $updateValues, $bean->id );
+                    $bean->setMeta( 'changed', FALSE );
+                }
+                $bean->setMeta( 'tainted', FALSE );
+            }
+        }
+    }
+
+    /**
 	 * Exception handler.
 	 * Fluid and Frozen mode have different ways of handling
 	 * exceptions. Fluid mode (using the fluid repository) ignores

--- a/RedBeanPHP/Repository/Fluid.php
+++ b/RedBeanPHP/Repository/Fluid.php
@@ -258,8 +258,11 @@ class Fluid extends Repository
 					$bean->id = $this->writer->updateRecord( $table, $updateValues, $bean->id );
 					$bean->setMeta( 'changed', FALSE );
 				}
-				$bean->setMeta( 'tainted', FALSE );
 			}
+		}
+
+		foreach ( $beans as $bean ) {
+			$bean->setMeta( 'tainted', FALSE );
 		}
 	}
 

--- a/RedBeanPHP/Repository/Fluid.php
+++ b/RedBeanPHP/Repository/Fluid.php
@@ -118,11 +118,13 @@ class Fluid extends Repository
 					$this->writer->widenColumn( $table, $property, $typeno );
 					$bean->setMeta( 'buildreport.flags.widen', TRUE );
 					$doFKStuff = TRUE;
+					$columns = NULL;    // Flush column cache
 				}
 			} else {
 				$this->writer->addColumn( $table, $property, $typeno );
 				$bean->setMeta( 'buildreport.flags.addcolumn', TRUE );
 				$doFKStuff = TRUE;
+				$columns = NULL;    // Flush column cache
 			}
 			if ($doFKStuff) {
 				if (strrpos($columnNoQ, '_id')===(strlen($columnNoQ)-3)) {

--- a/RedBeanPHP/Repository/Frozen.php
+++ b/RedBeanPHP/Repository/Frozen.php
@@ -90,7 +90,24 @@ class Frozen extends Repository
 		$bean->setMeta( 'tainted', FALSE );
 	}
 
-	/**
+    /**
+     * Stores cleaned beans; i.e. only scalar values. This is the core of the store()
+     * method. When all lists and embedded beans (parent objects) have been processed and
+     * removed from the original bean the bean is passed to this method to be stored
+     * in the database.
+     *
+     * @param array $beans the clean beans
+     *
+     * @return void
+     */
+    protected function storeAllBeans( $beans )
+    {
+        foreach ( $beans as $bean ) {
+            $this->storeBean( $bean );
+        }
+    }
+
+    /**
 	 * Part of the store() functionality.
 	 * Handles all new additions after the bean has been saved.
 	 * Stores addition bean in own-list, extracts the id and

--- a/RedBeanPHP/Repository/Frozen.php
+++ b/RedBeanPHP/Repository/Frozen.php
@@ -63,7 +63,7 @@ class Frozen extends Repository
 	 *
 	 * @return void
 	 */
-	protected function storeBean( OODBBean $bean )
+	private function storeBean( OODBBean $bean )
 	{
 		if ( $bean->getMeta( 'changed' ) ) {
 
@@ -100,7 +100,7 @@ class Frozen extends Repository
 	 *
 	 * @return void
 	 */
-	protected function storeAllBeans( $beans )
+	protected function storeCleanedBeans( $beans )
 	{
 		foreach ( $beans as $bean ) {
 			$this->storeBean( $bean );

--- a/RedBeanPHP/Repository/Frozen.php
+++ b/RedBeanPHP/Repository/Frozen.php
@@ -90,24 +90,24 @@ class Frozen extends Repository
 		$bean->setMeta( 'tainted', FALSE );
 	}
 
-    /**
-     * Stores cleaned beans; i.e. only scalar values. This is the core of the store()
-     * method. When all lists and embedded beans (parent objects) have been processed and
-     * removed from the original bean the bean is passed to this method to be stored
-     * in the database.
-     *
-     * @param array $beans the clean beans
-     *
-     * @return void
-     */
-    protected function storeAllBeans( $beans )
-    {
-        foreach ( $beans as $bean ) {
-            $this->storeBean( $bean );
-        }
-    }
+	/**
+	 * Stores cleaned beans; i.e. only scalar values. This is the core of the store()
+	 * method. When all lists and embedded beans (parent objects) have been processed and
+	 * removed from the original bean the bean is passed to this method to be stored
+	 * in the database.
+	 *
+	 * @param array $beans the clean beans
+	 *
+	 * @return void
+	 */
+	protected function storeAllBeans( $beans )
+	{
+		foreach ( $beans as $bean ) {
+			$this->storeBean( $bean );
+		}
+	}
 
-    /**
+	/**
 	 * Part of the store() functionality.
 	 * Handles all new additions after the bean has been saved.
 	 * Stores addition bean in own-list, extracts the id and

--- a/testing/RedUNIT/Base/Update.php
+++ b/testing/RedUNIT/Base/Update.php
@@ -31,7 +31,7 @@ class Update extends Base
 	/**
 	 * Tests whether no unncessary DESCRIBE-queries are executed,
 	 * (Commit 3b8ce88e5b796bfde6485ab0a51a4fcfb1bcf0fa by davidsickmiller).
-	 * Even thtough we add 2 properties, only 1 DESCRIBE query is necessary
+	 * Even though we have 2 properties, only 1 DESCRIBE query is necessary
 	 * to load the column cache.
 	 */
 	public function testModifySchemaColCache()
@@ -57,6 +57,15 @@ class Update extends Base
 		R::stopLogging();
 		//new round, same results, no cache between beans
 		R::nuke();
+
+		// Modifying the schema may cause multiple DESCRIBES, so
+		// make sure the columns exist first
+		$bean = R::dispense('bean');
+		$bean->property1 = 'test';
+		$bean->property2 = 'test';
+		R::store( $bean );
+
+		// Now the schema exists, so further stores should be very efficient
 		$bean = R::dispense('bean');
 		$bean->property1 = 'test';
 		$bean->property2 = 'test'; //should not cause 2nd DESCRIBE.

--- a/testing/RedUNIT/Base/Update.php
+++ b/testing/RedUNIT/Base/Update.php
@@ -42,6 +42,15 @@ class Update extends Base
 		$database = $toolbox->getDatabaseAdapter()->getDatabase();
 		$logger = new Logger;
 		$database->setLogger( $logger );
+
+		// Modifying the schema may cause multiple DESCRIBES, so
+		// make sure the columns exist first
+		$bean = R::dispense('bean');
+		$bean->property1 = 'test';
+		$bean->property2 = 'test';
+		R::store( $bean );
+
+		// Now the schema exists, so further stores should be very efficient
 		$bean = R::dispense('bean');
 		$bean->property1 = 'test';
 		$bean->property2 = 'test'; //should not cause 2nd DESCRIBE.
@@ -55,6 +64,8 @@ class Update extends Base
 			count( $logger->grep('PRAGMA table_info') )
 		, 1);
 		R::stopLogging();
+
+
 		//new round, same results, no cache between beans
 		R::nuke();
 


### PR DESCRIPTION
storeAll() can be very inefficient in fluid mode, as we do uncached SHOW TABLES and DESCRIBE operations for each bean.

If we change storeAll() to send the whole batch to Fluid.php (or Frozen.php), it can operate more efficiently.


Note: I'm having trouble running the phpunit test locally.... hoping creating a draft PR will be sufficient to see the test results in Travis CI