### PR TITLE
Bug fix - removeToolBoxByKey didn't remove

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -2758,10 +2758,11 @@ class Facade
 	 */
 	public static function removeToolBoxByKey( $key )
 	{
-		if ( !array_key_exists( $key, self::$toolboxes ) ) {
-			return FALSE;
+		if ( isset( self::$toolboxes[$key] ) ) {
+			unset( self::$toolboxes[$key] );
+			return TRUE;
 		}
-		return TRUE;
+		return FALSE;
 	}
 
 	/**


### PR DESCRIPTION
removeToolBoxByKey was missing an unset
Also made a small optimisation by swapping !array_key_exists() for the faster isset()  ($toolBoxes array can't contain NULL values)