### PR TITLE
Dispense parent bean if field link is null

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1087,7 +1087,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 		$exists         = isset( $this->properties[$property] );
 
 		//If not exists and no field link and no list, bail out.
-		if ( !$exists && !isset($this->$fieldLink) && (!$isOwn && !$isShared )) {
+		if ( !$exists && !array_key_exists( $fieldLink, $this->properties ) && (!$isOwn && !$isShared )) {
 			$this->clearModifiers();
 			/**
 			 * Github issue:
@@ -1125,7 +1125,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 		list( $redbean, , , $toolbox ) = $this->beanHelper->getExtractedToolbox();
 
 		//If it's another bean, then we load it and return
-		if ( isset( $this->$fieldLink ) ) {
+		if ( array_key_exists( $fieldLink, $this->properties ) ) {
 			$this->__info['tainted'] = TRUE;
 			if ( isset( $this->__info["sys.parentcache.$property"] ) ) {
 				$bean = $this->__info["sys.parentcache.$property"];
@@ -1138,8 +1138,10 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 				} else {
 					$type = $property;
 				}
-				$bean = NULL;
-				if ( !is_null( $this->properties[$fieldLink] ) ) {
+				
+				if ( $this->properties[$fieldLink] === NULL ) {
+					$bean = $redbean->dispense( $type );
+				} else {
 					$bean = $redbean->load( $type, $this->properties[$fieldLink] );
 					//If the IDs dont match, we failed to load, so try autoresolv in that case...
 					if ( $bean->id !== $this->properties[$fieldLink] && self::$autoResolve ) {


### PR DESCRIPTION
Parent bean is dispensed if the corresponding field link exists but is null, instead of doing nothing. This change makes it safer to use a parent bean because it's implicitly dispensed if necessary

So you can do the following without causing an error:

```php
// Given that $foo has previously been stored with bar_id = NULL
$foo = R::load( 'foo', 123 );
echo $foo->bar->getMeta( 'type' );
```

Previously the above would throw "Fatal error: Call to a member function getMeta() on null"

```php
$foo->bar->baz = 'baz';
```

Previously the above would create bar as a stdClass object and emit a warning


There's still a couple of scenarios however where you won't be guaranteed a dispensed parent:

- Dispensing a new (child) bean
- Loading a (child) bean with an invalid ID

In both cases the foo_id field won't exist, but this is easily avoided either by adding a check for the bean's id, or by using a model class to add default fields eg:

```
class Model_Foo extends \RedBeanPHP\SimpleModel {

    public function dispense()
    {
        $this->bean->bar_id = NULL;
    }

}
```

Because the bean requires the bar_id field to exist in order to dispense bar it does mean that this feature is more useful in frozen mode than it is in fluid