### PR TITLE
Stop unassociation if association not found

### DIFF
--- a/RedBeanPHP/AssociationManager.php
+++ b/RedBeanPHP/AssociationManager.php
@@ -276,6 +276,9 @@ class AssociationManager extends Observable
 					$type2 = $bean2->getMeta( 'type' );
 
 					$row      = $this->writer->queryRecordLink( $type1, $type2, $bean1->id, $bean2->id );
+
+					if ( !$row ) return;
+
 					$linkType = $this->getTable( array( $type1, $type2 ) );
 
 					if ( $fast ) {


### PR DESCRIPTION
In PHP this is fine:
```php
$a = false;
var_dump($a['id']); // NULL
```
The last commit changed what `GetRow()` returns so we now need to check for `$row` here and can't just try to get an undefined index from it.