### PR TITLE
Don't always clear cache on find/load FOR UPDATE

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -653,10 +653,7 @@ class Facade
 	 */
 	public static function load( $type, $id, $snippet = NULL )
 	{
-		if ( $snippet !== NULL ) {
-			self::$writer->clearCache();
-			self::$writer->setSQLSelectSnippet( $snippet );
-		}
+		if ( $snippet !== NULL ) self::$writer->setSQLSelectSnippet( $snippet );
 		$bean = self::$redbean->load( $type, $id );
 		return $bean;
 	}
@@ -884,10 +881,7 @@ class Facade
 	 */
 	public static function find( $type, $sql = NULL, $bindings = array(), $snippet = NULL )
 	{
-		if ( $snippet !== NULL ) {
-			self::$writer->clearCache();
-			self::$writer->setSQLSelectSnippet( $snippet );
-		}
+		if ( $snippet !== NULL ) self::$writer->setSQLSelectSnippet( $snippet );
 		return self::$finder->find( $type, $sql, $bindings );
 	}
 

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -934,12 +934,12 @@ abstract class AQueryWriter
 
 		$fieldSelection = ( self::$flagNarrowFieldMode ) ? "{$table}.*" : '*';
 		$sql   = "SELECT {$fieldSelection} {$sqlFilterStr} FROM {$table} {$sql} {$this->sqlSelectSnippet} -- keep-cache";
+		$this->sqlSelectSnippet = '';
 		$rows  = $this->adapter->get( $sql, $bindings );
 
-		if ( $this->flagUseCache && $this->sqlSelectSnippet != self::C_SELECT_SNIPPET_FOR_UPDATE ) {
+		if ( $this->flagUseCache && !empty( $key ) ) {
 			$this->putResultInCache( $type, $key, $rows );
 		}
-		$this->sqlSelectSnippet = '';
 
 		return $rows;
 	}

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1352,7 +1352,7 @@ abstract class AQueryWriter
 			$this->cache = array();
 			return $count;
 		}
-		$this->cache = array()
+		$this->cache = array();
 	}
 
 	/**

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1347,12 +1347,9 @@ abstract class AQueryWriter
 		if ( !is_null( $newMaxCacheSizePerType ) && $newMaxCacheSizePerType > 0 ) {
 			$this->maxCacheSizePerType = $newMaxCacheSizePerType;
 		}
-		if ( $countCache ) {
-			$count = count( $this->cache, COUNT_RECURSIVE );
-			$this->cache = array();
-			return $count;
-		}
+		$count = $countCache ? count( $this->cache, COUNT_RECURSIVE ) : NULL;
 		$this->cache = array();
+		return $count;
 	}
 
 	/**

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -334,14 +334,6 @@ abstract class AQueryWriter
 	}
 
 	/**
-	 * Explicitly clears writer cache.
-	 */
-	public function clearCache()
-	{
-		$this->cache = array();
-	}
-
-	/**
 	 * Stores data from the writer in the cache under a specific key and cache tag.
 	 * A cache tag is used to make sure the cache remains consistent. In most cases the cache tag
 	 * will be the bean type, this makes sure queries associated with a certain reference type will
@@ -920,7 +912,7 @@ abstract class AQueryWriter
 	 */
 	public function queryRecord( $type, $conditions = array(), $addSql = NULL, $bindings = array() )
 	{
-		if ( $this->flagUseCache ) {
+		if ( $this->flagUseCache && $this->sqlSelectSnippet != self::C_SELECT_SNIPPET_FOR_UPDATE ) {
 			$key = $this->getCacheKey( array( $conditions, trim("$addSql {$this->sqlSelectSnippet}"), $bindings, 'select' ) );
 			if ( $cached = $this->getCached( $type, $key ) ) {
 				return $cached;
@@ -942,12 +934,12 @@ abstract class AQueryWriter
 
 		$fieldSelection = ( self::$flagNarrowFieldMode ) ? "{$table}.*" : '*';
 		$sql   = "SELECT {$fieldSelection} {$sqlFilterStr} FROM {$table} {$sql} {$this->sqlSelectSnippet} -- keep-cache";
-		$this->sqlSelectSnippet = '';
 		$rows  = $this->adapter->get( $sql, $bindings );
 
-		if ( $this->flagUseCache ) {
+		if ( $this->flagUseCache && $this->sqlSelectSnippet != self::C_SELECT_SNIPPET_FOR_UPDATE ) {
 			$this->putResultInCache( $type, $key, $rows );
 		}
+		$this->sqlSelectSnippet = '';
 
 		return $rows;
 	}
@@ -1348,16 +1340,19 @@ abstract class AQueryWriter
 	 * Clears the internal query cache array and returns its overall
 	 * size.
 	 *
-	 * @return integer
+	 * @return mixed
 	 */
-	public function flushCache( $newMaxCacheSizePerType = NULL )
+	public function flushCache( $newMaxCacheSizePerType = NULL, $countCache = TRUE )
 	{
 		if ( !is_null( $newMaxCacheSizePerType ) && $newMaxCacheSizePerType > 0 ) {
 			$this->maxCacheSizePerType = $newMaxCacheSizePerType;
 		}
-		$count = count( $this->cache, COUNT_RECURSIVE );
-		$this->cache = array();
-		return $count;
+		if ( $countCache ) {
+			$count = count( $this->cache, COUNT_RECURSIVE );
+			$this->cache = array();
+			return $count;
+		}
+		$this->cache = array()
 	}
 
 	/**


### PR DESCRIPTION
Here is my take on this.

I removed `clearCache` because we already have `flushCache`.
I just added an argument to prevent it from counting the cache if that's not needed.

Also moved the FOR UPDATE cache fix in `queryRecord` so that we don't have to wipe the whole cache for this.

Let me know what you think @gabordemooij 