### PR TITLE
Have trash/trashAll return number of deleted beans

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1953,9 +1953,11 @@ class Facade
 	 */
 	public static function trashAll( $beans )
 	{
+		$numberOfDeletion = 0;
 		foreach ( $beans as $bean ) {
-			self::trash( $bean );
+			$numberOfDeletion += self::trash( $bean );
 		}
+		return $numberOfDeletion;
 	}
 
 	/**

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1251,7 +1251,7 @@ abstract class AQueryWriter
 		
 		$sql    = "DELETE FROM {$table} {$sql}";
 
-		$this->adapter->exec( $sql, $bindings );
+		return $this->adapter->exec( $sql, $bindings );
 	}
 
 	/**

--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -636,12 +636,13 @@ abstract class Repository
 			}
 		}
 		try {
-			$this->writer->deleteRecord( $bean->getMeta( 'type' ), array( 'id' => array( $bean->id ) ), NULL );
+			$deleted = $this->writer->deleteRecord( $bean->getMeta( 'type' ), array( 'id' => array( $bean->id ) ), NULL );
 		} catch ( SQLException $exception ) {
 			$this->handleException( $exception );
 		}
 		$bean->id = 0;
 		$this->oodb->signal( 'after_delete', $bean );
+		return $deleted ? $deleted : 0;
 	}
 
 	/**

--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -642,7 +642,7 @@ abstract class Repository
 		}
 		$bean->id = 0;
 		$this->oodb->signal( 'after_delete', $bean );
-		return $deleted ? $deleted : 0;
+		return isset($deleted) ? $deleted : 0;
 	}
 
 	/**


### PR DESCRIPTION
This is a proposal for #736 

```php
$book = R::load( 'book', 1 );
R::trash( $book ); // Returns 1

// ------

$books = R::findAll( 'book' );
count( $books ); // Returns 8
R::trashAll( $books ); // Returns 8

// ------

$book = R::dispense( 'book' );
R::store( $book );
$page = R::dispense( 'page' ); // We don't store it

// This will return 1 since $page doesn't get trashed
R::trashAll( [ $book, $page ] );
