### PR TITLE
Allow findLike (and the likes) to use "IS NULL" conditions

### DIFF
--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -387,7 +387,10 @@ abstract class AQueryWriter
 
 		$sqlConditions = array();
 		foreach ( $conditions as $column => $values ) {
-			if ( $values === NULL ) continue;
+			if ( $values === NULL ) {
+				$sqlConditions[] = $this->esc( $column ) . ' IS NULL';
+				continue;
+			}
 
 			if ( is_array( $values ) ) {
 				if ( empty( $values ) ) continue;


### PR DESCRIPTION
This modifies makeSQLFromConditions so that it is able to add a `condition IS NULL` if the value linked to a property is NULL.

```php
R::findLike( 'book', [ 'title' => NULL ] );

// Previously would execute this query
// SELECT * FROM `books`

// Would now execute this query
// SELECT * FROM `books` WHERE `title` IS NULL
```

Technically, this breaks BC.
But I don't think anyone would actually pass NULL values to the $conditions argument directly and if there's special cases where it could happen, I'm sure they are very rare.

One of the special case that could exist somewhere I guess:
```php
$title = $_GET['title'] ?? NULL;

// If there's a title, load that specific book, otherwise list them all:
R::findLike( 'book', [ 'title' => $title ] );
```