### PR TITLE
Changes writer's wipeAll to nuke and add R::wipeAll

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1688,7 +1688,9 @@ class Facade
 	 */
 	public static function wipeAll()
 	{
-		return Facade::$redbean->wipeAll();
+		foreach ( self::$writer->getTables() as $t ) {
+			self::wipe($t);
+		}
 	}
 
 	/**

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -1682,6 +1682,16 @@ class Facade
 	}
 
 	/**
+	 * Wipes all beans of all types.
+	 *
+	 * @return boolean
+	 */
+	public static function wipeAll()
+	{
+		return Facade::$redbean->wipeAll();
+	}
+
+	/**
 	 * Counts the number of beans of type $type.
 	 * This method accepts a second argument to modify the count-query.
 	 * A third argument can be used to provide bindings for the SQL snippet.
@@ -1933,7 +1943,7 @@ class Facade
 	public static function nuke()
 	{
 		if ( !self::$redbean->isFrozen() ) {
-			self::$writer->wipeAll();
+			self::$writer->nuke();
 		}
 	}
 

--- a/RedBeanPHP/QueryWriter.php
+++ b/RedBeanPHP/QueryWriter.php
@@ -477,7 +477,7 @@ interface QueryWriter
 	 *
 	 * @return void
 	 */
-	public function wipeAll();
+	public function nuke();
 
 	/**
 	 * Renames an association. For instance if you would like to refer to

--- a/RedBeanPHP/QueryWriter/CUBRID.php
+++ b/RedBeanPHP/QueryWriter/CUBRID.php
@@ -339,9 +339,9 @@ class CUBRID extends AQueryWriter implements QueryWriter
 	}
 
 	/**
-	 * @see QueryWriter::wipeAll
+	 * @see QueryWriter::nuke
 	 */
-	public function wipeAll()
+	public function nuke()
 	{
 		if (AQueryWriter::$noNuke) throw new \Exception('The nuke() command has been disabled using noNuke() or R::feature(novice/...).');
 		foreach ( $this->getTables() as $t ) {

--- a/RedBeanPHP/QueryWriter/Firebird.php
+++ b/RedBeanPHP/QueryWriter/Firebird.php
@@ -337,9 +337,9 @@ class Firebird extends AQueryWriter implements QueryWriter
 	}
 
 	/**
-	 * @see QueryWriter::wipeAll
+	 * @see QueryWriter::nuke
 	 */
-	public function wipeAll()
+	public function nuke()
 	{
 		if (AQueryWriter::$noNuke) throw new \Exception('The nuke() command has been disabled using noNuke() or R::feature(novice/...).');
 		$tables = $this->getTables();

--- a/RedBeanPHP/QueryWriter/MySQL.php
+++ b/RedBeanPHP/QueryWriter/MySQL.php
@@ -399,9 +399,9 @@ class MySQL extends AQueryWriter implements QueryWriter
 	}
 
 	/**
-	 * @see QueryWriter::wipeAll
+	 * @see QueryWriter::nuke
 	 */
-	public function wipeAll()
+	public function nuke()
 	{
 		if (AQueryWriter::$noNuke) throw new \Exception('The nuke() command has been disabled using noNuke() or R::feature(novice/...).');
 		$this->adapter->exec( 'SET FOREIGN_KEY_CHECKS = 0;' );

--- a/RedBeanPHP/QueryWriter/PostgreSQL.php
+++ b/RedBeanPHP/QueryWriter/PostgreSQL.php
@@ -402,9 +402,9 @@ class PostgreSQL extends AQueryWriter implements QueryWriter
 	}
 
 	/**
-	 * @see QueryWriter::wipeAll
+	 * @see QueryWriter::nuke
 	 */
-	public function wipeAll()
+	public function nuke()
 	{
 		if (AQueryWriter::$noNuke) throw new \Exception('The nuke() command has been disabled using noNuke() or R::feature(novice/...).');
 		$this->adapter->exec( 'SET CONSTRAINTS ALL DEFERRED' );

--- a/RedBeanPHP/QueryWriter/SQLiteT.php
+++ b/RedBeanPHP/QueryWriter/SQLiteT.php
@@ -450,9 +450,9 @@ class SQLiteT extends AQueryWriter implements QueryWriter
 	}
 
 	/**
-	 * @see QueryWriter::wipeAll
+	 * @see QueryWriter::nuke
 	 */
-	public function wipeAll()
+	public function nuke()
 	{
 		if (AQueryWriter::$noNuke) throw new \Exception('The nuke() command has been disabled using noNuke() or R::feature(novice/...).');
 		$this->adapter->exec( 'PRAGMA foreign_keys = 0 ' );

--- a/testing/RedUNIT/Blackhole/Stub.php
+++ b/testing/RedUNIT/Blackhole/Stub.php
@@ -109,7 +109,7 @@ class Stub extends Base
 		$mockdapter->errorExec = NULL;
 		$writer->addIndex( $type, $name, $column );
 		pass();
-		$writer->wipeAll();
+		$writer->nuke();
 		pass();
 		$mockdapter->answerGetCol = array( 'table1' );
 		$mockdapter->answerGetSQL = array(
@@ -117,7 +117,7 @@ class Stub extends Base
 				'CREATE TABLE' => 'CONSTRAINT [key] FOREIGN KEY ([bean]) REFERENCES [bean] ON DELETE CASCADE ON UPDATE RESTRICT'
 			)
 		);
-		$writer->wipeAll();
+		$writer->nuke();
 		pass();
 		$writer->esc( $dbStructure, $noQuotes = FALSE );
 		pass();


### PR DESCRIPTION
The writer's function `wipe` **truncates** a table but its `wipeAll` function **drops** them.
To be consistent with `R::wipe` and `R::nuke` I changed `wipeAll` to `nuke` in the writer.

I also added a `R::wipeAll` which simply truncates all tables and saves having to write the simple loop ourselves (#770).

Don't have the time to write tests for that yet.