### PR TITLE
Improve the sql check in glueLimitOne

### DIFF
--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -827,7 +827,7 @@ abstract class AQueryWriter
 	 */
 	public function glueLimitOne( $sql = '')
 	{
-		return ( strpos( strtoupper( $sql ), 'LIMIT' ) === FALSE ) ? ( $sql . ' LIMIT 1 ' ) : $sql;
+		return ( strpos( strtoupper( ' ' . $sql ), ' LIMIT ' ) === FALSE ) ? ( $sql . ' LIMIT 1 ' ) : $sql;
 	}
 
 	/**


### PR DESCRIPTION
It doesn't make it totally foolproof, but it mitigates a bit more than it previously did.
Here is an example that wouldn't pass the test before:
```php
R::fancyDebug( TRUE );
$highway = R::findOne('highway', ' limitation IS NULL ');

// Debug would print the following:
// SELECT `highway`.*  FROM `highway`  WHERE  limitation IS NULL   -- keep-cache
// resultset: 2 rows
```