### PR TITLE
Allow an array of values to be used as meta-mask

### DIFF
--- a/RedBeanPHP/Repository.php
+++ b/RedBeanPHP/Repository.php
@@ -593,7 +593,7 @@ abstract class Repository
 					if ( !is_string( $m ) ) {
 						$mask = NULL;
 						$masktype = 'NULL';
-						break;
+						break 2;
 					}
 					$maskflip[$m] = TRUE;
 				}


### PR DESCRIPTION
Also adds some checks to $mask to whitelist the type of inputs allowed.

Usage example:
```php
    $rows = R::getRow( 'SELECT book.*, COUNT(page.id) AS pages, COUNT(review.id) AS reviews... ' );
    $book = R::convertToBean( 'book', $row, [ 'pages', 'reviews' ] );
    $metadata = $book->getMeta( 'data.bundle' );
    echo $metadata['pages'];
    echo $metadata['reviews'];
```

It gives a bit more flexibility when working with SQL you don't have control over for example.
Let me know what you think about it.