### PR TITLE
Fix range of allowed characters for plugin name

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -3106,7 +3106,7 @@ class Facade
 	public static function ext( $pluginName, $callable )
 	{
 		if ( !preg_match( '#^[a-zA-Z_][a-zA-Z0-9_]*$#', $pluginName ) ) {
-			throw new RedException( 'Plugin name may only contain alphanumeric characters.' );
+			throw new RedException( 'Plugin name may only contain alphanumeric characters and underscores and cannot start with a number.' );
 		}
 		self::$plugins[$pluginName] = $callable;
 	}
@@ -3124,7 +3124,7 @@ class Facade
 	{
 		if ( !isset( self::$plugins[$pluginName] ) ) {
 			if ( !preg_match( '#^[a-zA-Z_][a-zA-Z0-9_]*$#', $pluginName ) ) {
-				throw new RedException( 'Plugin name may only contain alphanumeric characters.' );
+				throw new RedException( 'Plugin name may only contain alphanumeric characters and underscores and cannot start with a number.' );
 			}
 			throw new RedException( 'Plugin \''.$pluginName.'\' does not exist, add this plugin using: R::ext(\''.$pluginName.'\')' );
 		}

--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -3105,7 +3105,7 @@ class Facade
 	 */
 	public static function ext( $pluginName, $callable )
 	{
-		if ( !ctype_alnum( $pluginName ) ) {
+		if ( !preg_match( '#^[a-zA-Z_][a-zA-Z0-9_]*$#', $pluginName ) ) {
 			throw new RedException( 'Plugin name may only contain alphanumeric characters.' );
 		}
 		self::$plugins[$pluginName] = $callable;
@@ -3122,10 +3122,10 @@ class Facade
 	 */
 	public static function __callStatic( $pluginName, $params )
 	{
-		if ( !ctype_alnum( $pluginName) ) {
-			throw new RedException( 'Plugin name may only contain alphanumeric characters.' );
-		}
 		if ( !isset( self::$plugins[$pluginName] ) ) {
+			if ( !preg_match( '#^[a-zA-Z_][a-zA-Z0-9_]*$#', $pluginName ) ) {
+				throw new RedException( 'Plugin name may only contain alphanumeric characters.' );
+			}
 			throw new RedException( 'Plugin \''.$pluginName.'\' does not exist, add this plugin using: R::ext(\''.$pluginName.'\')' );
 		}
 		return call_user_func_array( self::$plugins[$pluginName], $params );

--- a/testing/RedUNIT/Blackhole/Plugins.php
+++ b/testing/RedUNIT/Blackhole/Plugins.php
@@ -62,14 +62,14 @@ class Plugins extends Blackhole
 			R::ext( '---', function() {} );
 			fail();
 		} catch ( RedException $e ) {
-			asrt( $e->getMessage(), 'Plugin name may only contain alphanumeric characters.' );
+			asrt( $e->getMessage(), 'Plugin name may only contain alphanumeric characters and underscores and cannot start with a number.' );
 		}
 
 		try {
 			R::__callStatic( '---', function() {} );
 			fail();
 		} catch ( RedException $e ) {
-			asrt( $e->getMessage(), 'Plugin name may only contain alphanumeric characters.' );
+			asrt( $e->getMessage(), 'Plugin name may only contain alphanumeric characters and underscores and cannot start with a number.' );
 		}
 
 		try {


### PR DESCRIPTION
The current implementation was allowing creating a plugin that starts with an number even though it would then be unusable as functions cannot start with a number in PHP and it would result in a parse error.

```php
// This works
R::ext( '911', function() {
    print 'Call the police!';
});

// This throws a parse error
R::911();
```

I fixed that and, while not allowing the entirety of allowed unicode since it can create more errors, allowed the underscore as well.

I also modified the `__callStatic` function as we don't need to check the name if it is already registered and fixed related tests.