### PR TITLE
Move parseJoin to QueryWrite

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -287,6 +287,16 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 	}
 
 	/**
+	 * Return list of global aliases
+	 *
+	 * @return array
+	 */
+	public static function getAliases()
+	{
+		return self::$aliases;
+	}
+
+	/**
 	 * Enables or disables auto-resolving fetch types.
 	 * Auto-resolving aliased parent beans is convenient but can
 	 * be slower and can create infinite recursion if you

--- a/RedBeanPHP/QueryWriter.php
+++ b/RedBeanPHP/QueryWriter.php
@@ -65,6 +65,27 @@ interface QueryWriter
 	const C_GLUE_AND   = 2;
 
 	/**
+	 * Parses an sql string to create joins if needed.
+	 *
+	 * For instance with $type = 'book' and $sql = ' @joined.author.name LIKE ? OR @joined.detail.title LIKE ? '
+	 * parseJoin will return the following SQL:
+	 * ' LEFT JOIN `author` ON `author`.id = `book`.author_id
+	 *   LEFT JOIN `detail` ON `detail`.id = `book`.detail_id
+	 *   WHERE author.name LIKE ? OR detail.title LIKE ? '
+	 *
+	 * @note this feature requires Narrow Field Mode to be activated (default).
+	 *
+	 * @note A default implementation is available in AQueryWriter
+	 * unless a database uses very different SQL this should suffice.
+	 *
+	 * @param string $type the source type for the join
+	 * @param string $sql  the sql string to be parsed
+	 *
+	 * @return string
+	 */
+	public function parseJoin( $type, $sql );
+
+	/**
 	 * Writes an SQL Snippet for a JOIN, returns the
 	 * SQL snippet string.
 	 *

--- a/RedBeanPHP/QueryWriter.php
+++ b/RedBeanPHP/QueryWriter.php
@@ -98,7 +98,7 @@ interface QueryWriter
 	 *
 	 * @return string $joinSQLSnippet
 	 */
-	public function writeJoin( $type, $targetType, $joinType );
+	public function writeJoin( $type, $targetType, $leftRight, $joinType );
 
 	/**
 	 * Glues an SQL snippet to the beginning of a WHERE clause.

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -949,9 +949,18 @@ abstract class AQueryWriter
 			throw new RedException( 'Invalid JOIN.' );
 
 		$table = $this->esc( $type );
-		$targetTable = $this->esc( $targetType );
 		$field = $this->esc( $targetType, TRUE );
-		return " {$leftRight} JOIN {$targetTable} ON {$targetTable}.id = {$table}.{$field}_id ";
+		$aliases = OODBBean::getAliases();
+		if ( isset( $aliases[$targetType] ) ) {
+			$alias       = $this->esc( $targetType );
+			$targetTable = $this->esc( $aliases[$targetType] );
+			$joinSql     = " {$leftRight} JOIN {$targetTable} AS {$alias} ON {$alias}.id = {$table}.{$field}_id ";
+		} else {
+			$targetTable = $this->esc( $targetType );
+			$joinSql     = " {$leftRight} JOIN {$targetTable} ON {$targetTable}.id = {$table}.{$field}_id ";
+		}
+
+		return $joinSql;
 	}
 
 	/**

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -976,17 +976,27 @@ abstract class AQueryWriter
 			$rightField = "{$field}_id";
 
 			$linkTable      = $this->esc( $this->getAssocTable( array( $type, $destType ) ) );
-			$linkField      = $this->esc( $targetType, TRUE );
+			$linkField      = $this->esc( $destType, TRUE );
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
 
-			$joinSql = "
-				{$leftRight} JOIN {$linkTable}
-				INNER JOIN {$targetTable} ON (
-					{$targetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}
-					AND {$table}.{$leftField} = {$linkTable}.{$rightField}
-				)
-			";
+			if ( isset( $aliases[$targetType] ) ) {
+				$joinSql = "
+					{$leftRight} JOIN {$linkTable}
+					INNER JOIN {$targetTable} AS {$alias} ON (
+						{$alias}.{$linkLeftField} = {$linkTable}.{$linkRightField}
+						AND {$table}.{$leftField} = {$linkTable}.{$rightField}
+					)
+				";
+			} else {
+				$joinSql = "
+					{$leftRight} JOIN {$linkTable}
+					INNER JOIN {$targetTable} ON (
+						{$targetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}
+						AND {$table}.{$leftField} = {$linkTable}.{$rightField}
+					)
+				";
+			}
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1327,9 +1327,7 @@ abstract class AQueryWriter
 			$sql = $this->glueSQLCondition( $addSql );
 		}
 
-		$sql = $this->parseJoin( $type, $sql );
-
-		$sql    = "DELETE {$table} FROM {$table} {$sql}";
+		$sql    = "DELETE FROM {$table} {$sql}";
 
 		return $this->adapter->exec( $sql, $bindings );
 	}

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1033,10 +1033,11 @@ abstract class AQueryWriter
 			$sqlFilterStr = $this->getSQLFilterSnippet( $type );
 		}
 
+		$sql = $this->glueSQLCondition( $addSql, NULL );
+
 		$sql = $this->parseJoin( $type, $sql );
 		$fieldSelection = self::$flagNarrowFieldMode ? "{$table}.*" : '*';
 
-		$sql = $this->glueSQLCondition( $addSql, NULL );
 		$sql = "SELECT {$fieldSelection} {$sqlFilterStr} FROM {$table} {$sql} -- keep-cache";
 
 		return $this->adapter->getCursor( $sql, $bindings );

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -923,7 +923,7 @@ abstract class AQueryWriter
 			//Dont join more than once..
 			if ( !isset( $joins[$joinInfo] ) ) {
 				$joins[ $joinInfo ] = TRUE;
-				if ( !preg_match( "#JOIN\s+`?{$joinInfo}.*WHERE#i", $sql ) ) {
+				if ( !preg_match( "#JOIN\s+(\w*\s+AS\s+|`)?{$joinInfo}.*WHERE#i", $sql ) ) {
 					$joinSql .= $this->writeJoin( $type, $joinInfo, 'LEFT' );
 				}
 			}


### PR DESCRIPTION
In #767 I answered the question by stating that one should do the following:
```php
$whitelisted_users = R::find( 'user', ' JOIN `status` WHERE `status`.id = `user`.status_id AND `status`.whitelist = ? ', [ 1 ] );
```
And I thought, why not have the `@joined` shorthand also available in `find()` and such ?

I had to move it away from OODBBean (and the QueryWriter felt like the obvious choice) and I added it's to every type of non-custom query (which means none of the `get...()` etc) that only target 1 type of bean (which means none of the `...Related()`, `...Tagged()` etc).
Therefore, it is available for all functions that call `queryRecord()`, `queryRecordWithCursor()` and `queryRecordCount()`.

With this you can find the same beans as above by doing:
```php
$whitelisted_users = R::find( 'user', ' @joined.status.whitelist = ? ', [ 1 ] );
```

It is "intelligent" enough to join multiple tables and to not join tables already joined. So you can use those kind of SQL strings for example:
- ` @joined.status.whitelist = ? AND @joined.status.last_login = ? `
- ` WHERE id < ? AND (@joined.author.name LIKE ? OR @joined.detail.title LIKE ?) `

------

Okay now this is a bit "side" and could have been made into its own PR, but I thought I'll add it in this one anyway. I made it so that `@joined` is able to handle aliases if they were previously globally declared using `R::aliases`.
```php
R::aliases([ 'author' => 'person' ]);
$books = R::find('book', ' @joined.author.name LIKE ? ', [ 'A%' ]);
// Actual SQL: SELECT `book`.*  FROM `book`    LEFT JOIN `person` AS `author` ON `author`.id = `book`.author_id  WHERE  author.name LIKE 'A%'
```

------

At the moment this @joined system makes it so that it does `joined.id = bean.joined_id`.
Depending on what you think about this PR, I thought we could also add the other version of it (using @linked for example) which would do `bean.id = joined.bean_id`.

_No animals were harmed during the making of this PR and no unit tests were written either..._