### PR TITLE
Fix and improve autoResolve

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -465,7 +465,8 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 				if ( $key['table'] == $property ) {
 					// We will autoResolve if there's only one column that could match the type
 					if ( $alreadyResolved ) {
-						throw new RedException( "Ambiguous autoResolve for {$property} bean when loading own{$type}List." );
+						$this->aliasName = NULL;
+						break;
 					}
 					$this->aliasName = substr( $from, 0, -3 );
 					$alreadyResolved = TRUE;

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -465,8 +465,7 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 				if ( $key['table'] == $property ) {
 					// We will autoResolve if there's only one column that could match the type
 					if ( $alreadyResolved ) {
-						$this->aliasName = NULL;
-						break;
+						throw new RedException( "Ambiguous autoResolve for {$property} bean when loading own{$type}List." );
 					}
 					$this->aliasName = substr( $from, 0, -3 );
 					$alreadyResolved = TRUE;

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1186,11 +1186,11 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 			if ( isset( $this->__info["sys.parentcache.$property"] ) ) {
 				$bean = $this->__info["sys.parentcache.$property"];
 			} else {
-				if ( isset( self::$aliases[$property] ) ) {
-					$type = self::$aliases[$property];
-				} elseif ( $this->fetchType ) {
+				if ( $this->fetchType ) {
 					$type = $this->fetchType;
 					$this->fetchType = NULL;
+				} elseif ( isset( self::$aliases[$property] ) ) {
+					$type = self::$aliases[$property];
 				} elseif ( !is_null( $this->properties[$fieldLink] ) ) {
 					if ( self::$autoResolve ) {
 						$thisType = $this->__info['type'];

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -538,8 +538,8 @@ abstract class AQueryWriter
 			return NULL;
 		}
 
-		foreach( $map as $key ) {
-			if ( $key['from'] === $property ) return $key;
+		if ( isset( $map[$property] ) ) {
+			return $map[$property];
 		}
 		return NULL;
 	}
@@ -567,7 +567,7 @@ abstract class AQueryWriter
 	 *
 	 * @return array
 	 */
-	protected function getKeyMapForType( $type )
+	public function getKeyMapForType( $type )
 	{
 		return array();
 	}
@@ -1423,10 +1423,8 @@ abstract class AQueryWriter
 		$field = $this->esc( $property, TRUE ) . '_id';
 		$keys = $this->getKeyMapForType( $type );
 
-		foreach( $keys as $key ) {
-			if (
-				$key['from'] === $field
-			) return $key['table'];
+		if ( isset( $keys[$field]['table'] ) ) {
+			return $keys[$field]['table'];
 		}
 		return NULL;
 	}

--- a/RedBeanPHP/QueryWriter/CUBRID.php
+++ b/RedBeanPHP/QueryWriter/CUBRID.php
@@ -84,7 +84,7 @@ class CUBRID extends AQueryWriter implements QueryWriter
 	/**
 	 * @see AQueryWriter::getKeyMapForType
 	 */
-	protected function getKeyMapForType( $type  )
+	public function getKeyMapForType( $type  )
 	{
 		$sqlCode = $this->adapter->get("SHOW CREATE TABLE `{$type}`");
 		if (!isset($sqlCode[0])) return array();
@@ -95,7 +95,7 @@ class CUBRID extends AQueryWriter implements QueryWriter
 		$max = count($matches[0]);
 		for($i = 0; $i < $max; $i++) {
 			$label = $this->makeFKLabel( $matches[2][$i], $matches[3][$i], 'id' );
-			$list[ $label ] = array(
+			$list[ $matches[2][$i] ] = array(
 				'name' => $matches[1][$i],
 				'from' => $matches[2][$i],
 				'table' => $matches[3][$i],
@@ -371,10 +371,8 @@ class CUBRID extends AQueryWriter implements QueryWriter
 		$field = $this->esc( $property, TRUE ) . '_id';
 		$keys = $this->getKeyMapForType( $table );
 
-		foreach( $keys as $key ) {
-			if (
-				$key['from'] === $field
-			) return $key['table'];
+		if ( isset( $keys[$field]['table'] ) ) {
+			return $keys[$field]['table'];
 		}
 		return NULL;
 	}

--- a/RedBeanPHP/QueryWriter/Firebird.php
+++ b/RedBeanPHP/QueryWriter/Firebird.php
@@ -70,7 +70,7 @@ class Firebird extends AQueryWriter implements QueryWriter
 	/**
 	 * @see AQueryWriter::getKeyMapForType
 	 */
-	protected function getKeyMapForType( $type )
+	public function getKeyMapForType( $type )
 	{
 		$table = $this->esc( $type, TRUE );
 		$keys = $this->adapter->get('
@@ -97,7 +97,7 @@ class Firebird extends AQueryWriter implements QueryWriter
 		$keyInfoList = array();
 		foreach ( $keys as $k ) {
 			$label = $this->makeFKLabel( $k['from'], $k['table'], $k['to'] );
-			$keyInfoList[$label] = array(
+			$keyInfoList[$k['from']] = array(
 				'name'          => $k['name'],
 				'from'          => $k['from'],
 				'table'         => $k['table'],

--- a/RedBeanPHP/QueryWriter/MySQL.php
+++ b/RedBeanPHP/QueryWriter/MySQL.php
@@ -58,7 +58,7 @@ class MySQL extends AQueryWriter implements QueryWriter
 	/**
 	 * @see AQueryWriter::getKeyMapForType
 	 */
-	protected function getKeyMapForType( $type )
+	public function getKeyMapForType( $type )
 	{
 		$databaseName = $this->adapter->getCell('SELECT DATABASE()');
 		$table = $this->esc( $type, TRUE );
@@ -84,7 +84,7 @@ class MySQL extends AQueryWriter implements QueryWriter
 		$keyInfoList = array();
 		foreach ( $keys as $k ) {
 			$label = $this->makeFKLabel( $k['from'], $k['table'], $k['to'] );
-			$keyInfoList[$label] = array(
+			$keyInfoList[$k['from']] = array(
 				'name'          => $k['name'],
 				'from'          => $k['from'],
 				'table'         => $k['table'],

--- a/RedBeanPHP/QueryWriter/PostgreSQL.php
+++ b/RedBeanPHP/QueryWriter/PostgreSQL.php
@@ -73,7 +73,7 @@ class PostgreSQL extends AQueryWriter implements QueryWriter
 	/**
 	 * @see AQueryWriter::getKeyMapForType
 	 */
-	protected function getKeyMapForType( $type )
+	public function getKeyMapForType( $type )
 	{
 		$table = $this->esc( $type, TRUE );
 		$keys = $this->adapter->get( '
@@ -111,7 +111,7 @@ class PostgreSQL extends AQueryWriter implements QueryWriter
 		$keyInfoList = array();
 		foreach ( $keys as $k ) {
 			$label = $this->makeFKLabel( $k['from'], $k['table'], $k['to'] );
-			$keyInfoList[$label] = array(
+			$keyInfoList[$k['from']] = array(
 				'name'          => $k['name'],
 				'from'          => $k['from'],
 				'table'         => $k['table'],

--- a/RedBeanPHP/QueryWriter/SQLiteT.php
+++ b/RedBeanPHP/QueryWriter/SQLiteT.php
@@ -195,14 +195,14 @@ class SQLiteT extends AQueryWriter implements QueryWriter
 	/**
 	 * @see AQueryWriter::getKeyMapForType
 	 */
-	protected function getKeyMapForType( $type )
+	public function getKeyMapForType( $type )
 	{
 		$table = $this->esc( $type, TRUE );
 		$keys  = $this->adapter->get( "PRAGMA foreign_key_list('$table')" );
 		$keyInfoList = array();
 		foreach ( $keys as $k ) {
 			$label = $this->makeFKLabel( $k['from'], $k['table'], $k['to'] );
-			$keyInfoList[$label] = array(
+			$keyInfoList[$k['from']] = array(
 				'name'          => $label,
 				'from'          => $k['from'],
 				'table'         => $k['table'],

--- a/testing/RedUNIT/Base/Aliasing.php
+++ b/testing/RedUNIT/Base/Aliasing.php
@@ -33,6 +33,7 @@ class Aliasing extends Base
 	public function testAutoResolver()
 	{
 		R::nuke();
+		R::setAutoResolve( TRUE );
 		list( $project, $teacher, $student ) = R::dispenseAll( 'project,person,person' );
 		$teacher->name = 'teacher';
 		$student->name = 'student';
@@ -67,15 +68,15 @@ class Aliasing extends Base
 		//Also test the default implementation...
 		$nullWriter = new \NullWriter( R::getDatabaseAdapter() );
 		asrt( is_null( $nullWriter->inferFetchType( 'test', 'test' ) ), TRUE );
-		//Realteacher should take precedence over fetchAs-teacher, name conventions first!
-		//also: ensure we do not use autoresolv for anything except when truly necessary! (performance)
+		//Realteacher should NOT take precedence over fetchAs-teacher, as there's already a foreign key
+		//linking the table project and the table person on the teacher_id column
 		$realTeacher = R::dispense( 'teacher' );
 		$realTeacher->name = 'real';
 		R::store( $realTeacher );
 		//ID must be same
 		asrt( $realTeacher->id, $teacher->id );
 		$project = $project->fresh();
-		asrt( $project->teacher->name, 'real' );
+		asrt( $project->teacher->name, 'teacher' );
 	}
 
 	/**

--- a/testing/RedUNIT/Base/Aliasing.php
+++ b/testing/RedUNIT/Base/Aliasing.php
@@ -127,7 +127,7 @@ class Aliasing extends Base
 		//cached - same list
 		asrt( count( $ilse->ownProject ), 0);
 		//now test state
-		asrt( count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject ), 0);
+		asrt( count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject ), 2);
 		//now test state
 		$ilse = $ilse->fresh();
 		//attr clears state...

--- a/testing/RedUNIT/Base/Aliasing.php
+++ b/testing/RedUNIT/Base/Aliasing.php
@@ -127,7 +127,14 @@ class Aliasing extends Base
 		//cached - same list
 		asrt( count( $ilse->ownProject ), 0);
 		//now test state
-		asrt( count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject ), 2);
+		try {
+			count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject );
+			fail();
+		} catch ( \RedException $e ) {
+			asrt( $e->getMessage(), 'Ambiguous autoResolve for person bean when loading ownprojectList.');
+		} catch ( \Exception $e ) {
+			fail();
+		}
 		//now test state
 		$ilse = $ilse->fresh();
 		//attr clears state...

--- a/testing/RedUNIT/Base/Aliasing.php
+++ b/testing/RedUNIT/Base/Aliasing.php
@@ -127,14 +127,7 @@ class Aliasing extends Base
 		//cached - same list
 		asrt( count( $ilse->ownProject ), 0);
 		//now test state
-		try {
-			count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject );
-			fail();
-		} catch ( \RedException $e ) {
-			asrt( $e->getMessage(), 'Ambiguous autoResolve for person bean when loading ownprojectList.');
-		} catch ( \Exception $e ) {
-			fail();
-		}
+		asrt( count( $ilse->setAttr( 'a', 'b' )->alias( 'developer' )->ownProject ), 0);
 		//now test state
 		$ilse = $ilse->fresh();
 		//attr clears state...

--- a/testing/RedUNIT/Base/Writecache.php
+++ b/testing/RedUNIT/Base/Writecache.php
@@ -145,6 +145,7 @@ class Writecache extends Base
 	{
 		testpack( 'Testing WriteCache Query Writer Cache' );
 		R::setNarrowFieldMode( FALSE );
+		$oldAutoResolve = R::setAutoResolve( FALSE );
 		R::useWriterCache( FALSE );
 		R::debug( TRUE, 1 );
 		$logger = R::getDatabaseAdapter()->getDatabase()->getLogger();
@@ -254,6 +255,7 @@ class Writecache extends Base
 		asrt( count( $logger->grep( 'SELECT' ) ), 2 );
 		R::getWriter()->setUseCache( TRUE );
 		R::setNarrowFieldMode( TRUE );
+		R::setAutoResolve( $oldAutoResolve );
 	}
 
 	/**

--- a/testing/helpers/classes.php
+++ b/testing/helpers/classes.php
@@ -262,7 +262,7 @@ class FaultyWriter extends \RedBeanPHP\QueryWriter\MySQL
 		$exception->setSQLState( $this->sqlState );
 		throw $exception;
 	}
-	protected function getKeyMapForType( $type ){throw new \RedBeanPHP\RedException\SQL;}
+	public function getKeyMapForType( $type ){throw new \RedBeanPHP\RedException\SQL;}
 }
 
 /**


### PR DESCRIPTION
This is my take on the autoResolve issue.
I'll try to break down what it does/I did:

------

Here is what it does when loading a linked bean:
- If `fetchAs()` has been called, then we use that
- If an alias is globally set for the bean we're loading, then we use that
- If autoResolve is set:
  - If we are in Fluid mode:
    - We retrieve the FKs map for the bean (even if there's nothing to actually resolve, yes)
  - If we are in Frozen mode:
    - We retrieve the FKs map for the bean **only once and we cache it**.
  - We check the map (cached or not depending on mode) to see if there's something to resolve
- We load the bean

Here is what it does when loading an own list:
- If `alias()` has been called than we use that
- If autoResolve is set:
  - If we are in Fluid mode:
    - We retrieve the FKs map for the bean (even if there's nothing to actually resolve, yes)
  - If we are in Frozen mode:
    - We retrieve the FKs map for the bean **only once and we cache it**.
  - We check the map (cached or not depending on mode) to see if there's something to resolve _**unambiguously***_
- We load the beans

_*If the beans from the ownList can only refer to 1 column then it's ok. Otherwise it's not. ie:_
> If a "person" bean is loading its projects list and the project table contains `student_id` and a `teacher_id` which are both linked to the `person` table, then we don't know which one we are refering to if not explicitely set using `alias()`. In that case we don't autoresolve it.

------

I think the "real teacher" test in Base/Aliasing was flawed as explained in comments:
>Realteacher should NOT take precedence over fetchAs-teacher, as there's already a foreign key linking the table project and the table person on the teacher_id column

------

Performance-wise, it should be much better when Frozen, but worse when Fluid.
I'll take a bit more time to see if we could also cache in fluid and only reload the key map when the schema has been changed.