### PR TITLE
Allow chaining of joins with @ syntax

### DIFF
--- a/RedBeanPHP/QueryWriter.php
+++ b/RedBeanPHP/QueryWriter.php
@@ -80,11 +80,10 @@ interface QueryWriter
 	 *
 	 * @param string         $type the source type for the join
 	 * @param string         $sql  the sql string to be parsed
-	 * @param string|boolean $overrideLinkType override link field (for trees)
 	 *
 	 * @return string
 	 */
-	public function parseJoin( $type, $sql, $overrideLinkType = FALSE );
+	public function parseJoin( $type, $sql );
 
 	/**
 	 * Writes an SQL Snippet for a JOIN, returns the
@@ -93,14 +92,16 @@ interface QueryWriter
 	 * @note A default implementation is available in AQueryWriter
 	 * unless a database uses very different SQL this should suffice.
 	 *
-	 * @param string $type       source type
-	 * @param string $targetType target type (type to join)
-	 * @param string $joinType   type of join (possible: 'LEFT', 'RIGHT' or 'INNER')
-	 * @param string|boolean $overrideLinkType override link field (for trees)
+	 * @param string  $type         source type
+	 * @param string  $targetType   target type (type to join)
+	 * @param string  $leftRight    type of join (possible: 'LEFT', 'RIGHT' or 'INNER')
+	 * @param string  $joinType     relation between joined tables (possible: 'parent', 'own', 'shared')
+	 * @param boolean $firstOfChain is it the join of a chain (or the only join)
+	 * @param string  $suffix       suffix to add for aliasing tables (for joining same table multiple times)
 	 *
 	 * @return string $joinSQLSnippet
 	 */
-	public function writeJoin( $type, $targetType, $leftRight, $joinType, $overrideLinkType = FALSE );
+	public function writeJoin( $type, $targetType, $leftRight, $joinType, $firstOfChain, $suffix );
 
 	/**
 	 * Glues an SQL snippet to the beginning of a WHERE clause.

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1013,23 +1013,29 @@ abstract class AQueryWriter
 		if ( $joinType == 'shared' ) {
 			if ( isset( $aliases[$type] ) ) {
 				$field      = $this->esc( $aliases[$type], TRUE );
-				$linkTable  = $this->esc( $this->getAssocTable( array( $cteType ? $cteType : $aliases[$type], $destType ) ) );
+				$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $aliases[$type], $destType ) );
 			} else {
 				$field      = $this->esc( $type, TRUE );
-				$linkTable  = $this->esc( $this->getAssocTable( array( $cteType ? $cteType : $type, $destType ) ) );
+				$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $type, $destType ) );
 			}
+			$linkTable      = $this->esc( $assocTable );
+			$asLinkTable    = $this->esc( $assocTable.$suffix );
 			$leftField      = "id";
 			$rightField     = $cteType ? "{$cteType}_id" : "{$field}_id";
 			$linkField      = $this->esc( $destType, TRUE );
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
 
-			$joinSql = " {$leftRight} JOIN {$linkTable} ON {$table}.{$leftField} = {$linkTable}.{$rightField}";
+			$joinSql = " {$leftRight} JOIN {$linkTable}";
+			if ( isset( $aliases[$targetType] ) || $suffix ) {
+				$joinSql .= " AS {$asLinkTable}";
+			}
+			$joinSql .= " ON {$table}.{$leftField} = {$asLinkTable}.{$rightField}";
 			$joinSql .= " {$leftRight} JOIN {$targetTable}";
 			if ( isset( $aliases[$targetType] ) || $suffix ) {
 				$joinSql .= " AS {$asTargetTable}";
 			}
-			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}";
+			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$asLinkTable}.{$linkRightField}";
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -925,22 +925,20 @@ abstract class AQueryWriter
 		$expressions = $matches[1];
 		// Sort to make the joins from the longest to the shortest
 		uasort( $expressions, function($a, $b) {
-			return substr_count($b, '.') - substr_count($a, '.');
+			return substr_count( $b, '.' ) - substr_count( $a, '.' );
 		});
 
 		$nsuffix = 1;
 		foreach ( $expressions as $exp ) {
 			$explosion = explode( '.', $exp );
-
-			$joinType  = array_shift( $explosion );
 			$joinTable = $type;
-
-			$lastPart  = array_pop($explosion);
-			$lastKey   = count($explosion) - 1;
+			$joinType  = array_shift( $explosion );
+			$lastPart  = array_pop( $explosion );
+			$lastKey   = count( $explosion ) - 1;
 
 			// Let's check if we already joined that chain
 			// If that's the case we skip this
-			$joinKey  = implode('.', $explosion);
+			$joinKey  = implode( '.', $explosion );
 			foreach ( $joins as $chain => $suffix ) {
 				if ( strpos ( $chain, $joinKey ) === 0 ) {
 					$sql = str_replace( "@{$exp}", "{$explosion[$lastKey]}__rb{$suffix}.{$lastPart}", $sql );
@@ -953,7 +951,6 @@ abstract class AQueryWriter
 			// We loop on the elements of the join
 			$i = 0;
 			while ( TRUE ) {
-
 				$joinInfo = $explosion[$i];
 				if ($i) {
 					$joinType = $explosion[$i-1];
@@ -970,9 +967,7 @@ abstract class AQueryWriter
 				if ( !isset( $explosion[$i] ) ) {
 					break;
 				}
-
 			}
-
 			$nsuffix++;
 		}
 
@@ -1016,9 +1011,6 @@ abstract class AQueryWriter
 		$targetTable   = $this->esc( $destType );
 
 		if ( $joinType == 'shared' ) {
-			$leftField  = "id";
-			$rightField = $cteType ? "{$cteType}_id" : "{$field}_id";
-
 			if ( isset( $aliases[$type] ) ) {
 				$field      = $this->esc( $aliases[$type], TRUE );
 				$linkTable  = $this->esc( $this->getAssocTable( array( $cteType ? $cteType : $aliases[$type], $destType ) ) );
@@ -1026,6 +1018,8 @@ abstract class AQueryWriter
 				$field      = $this->esc( $type, TRUE );
 				$linkTable  = $this->esc( $this->getAssocTable( array( $cteType ? $cteType : $type, $destType ) ) );
 			}
+			$leftField      = "id";
+			$rightField     = $cteType ? "{$cteType}_id" : "{$field}_id";
 			$linkField      = $this->esc( $destType, TRUE );
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1024,11 +1024,12 @@ abstract class AQueryWriter
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
 
-			$joinSql = " {$leftRight} JOIN {$linkTable} INNER JOIN {$targetTable}";
+			$joinSql = " {$leftRight} JOIN {$linkTable} ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
+			$joinSql = " {$leftRight} JOIN {$targetTable}";
 			if ( isset( $aliases[$targetType] ) || $suffix ) {
 				$joinSql .= " AS {$asTargetTable}";
 			}
-			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField} ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
+			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}"
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -906,42 +906,72 @@ abstract class AQueryWriter
 	/**
 	 * @see QueryWriter::parseJoin
 	 */
-	public function parseJoin( $type, $sql, $overrideLinkType = FALSE )
+	public function parseJoin( $type, $sql )
 	{
 		if ( strpos( $sql, '@' ) === FALSE ) {
 			return $sql;
 		}
-		$aliases = OODBBean::getAliases();
+
 		$sql = ' ' . $sql;
 		$joins = array();
 		$joinSql = '';
-		$criteria = array();
-		$joins = array();
-		$startType = $type;
-		$matches = array();
-		if (!preg_match_all('/@((shared|own|joined)\.\S+)/', $sql, $matches)) return $sql;
-		if (count($matches)<3) return $sql;
+
+		if ( !preg_match_all( '#@((shared|own|joined)\.[^\s(,=!?]+)#', $sql, $matches) )
+			return $sql;
+
+		if ( count( $matches ) < 3 )
+			return $sql;
+
 		$expressions = $matches[1];
-		while( $expressionStr = array_shift( $expressions ) ) {
-			$expression = explode( '.', $expressionStr );
-			$type = $startType;
-			$i = 0;
-			while( $unit = array_splice( $expression, 0, 2 ) ) {
-				list( $joinType, $target ) = $unit;
-				if (!isset($joins["$type.$target"])) {
-					$joins["$type.$target"] = TRUE;
-					$joinSql .= $this->writeJoin( $type, $target, 'LEFT', $joinType, (!$i) ? $overrideLinkType : FALSE );
-				}
-				$type = $target;
-				$i ++;
-				if (count($expression)==1) {
-					$field = array_shift($expression);
-					$criteria[] = "{$target}.{$field}";
-					$sql = str_replace( "@$expressionStr", "{$target}.{$field}", $sql );
-					break;
+		// Sort to make the joins from the longest to the shortest
+		uasort( $expressions, function($a, $b) {
+			return substr_count($b, '.') - substr_count($a, '.');
+		});
+
+		$nsuffix = 1;
+		foreach ( $expressions as $exp ) {
+			$explosion = explode( '.', $exp );
+
+			$joinType  = array_shift( $explosion );
+			$joinTable = $type;
+
+			$lastPart  = array_pop($explosion);
+			$lastKey   = count($explosion) - 1;
+
+			// Let's check if we already joined that chain
+			// If that's the case we skip this
+			$joinKey  = implode('.', $explosion);
+			foreach ( $joins as $chain => $suffix ) {
+				if ( strpos ( $chain, $joinKey ) === 0 ) {
+					$sql = str_replace( "@{$exp}", "{$explosion[$lastKey]}__rb{$suffix}.{$lastPart}", $sql );
+					continue 2;
 				}
 			}
+			$sql = str_replace( "@{$exp}", "{$explosion[$lastKey]}__rb{$nsuffix}.{$lastPart}", $sql );
+			$joins[$joinKey] = $nsuffix;
+
+			// We loop on the elements of the join
+			$i = 0;
+			while ( TRUE ) {
+
+				$joinInfo = $explosion[$i];
+				if ($i) {
+					$joinType = $explosion[$i-1];
+					$joinTable = $explosion[$i-2];
+				}
+
+				$joinSql .= $this->writeJoin( $joinTable, $joinInfo, ($i ? 'INNER' : 'LEFT'), $joinType, ($i ? FALSE : TRUE), "__rb{$nsuffix}" );
+
+				$i += 2;
+				if ( !isset( $explosion[$i] ) ) {
+					break;
+				}
+
+			}
+
+			$nsuffix++;
 		}
+
 		$sql = str_ireplace( ' where ', ' WHERE ', $sql );
 		if ( strpos( $sql, ' WHERE ') === FALSE ) {
 			if ( preg_match( '/^(ORDER|GROUP|HAVING|LIMIT|OFFSET)\s+/i', trim($sql) ) ) {
@@ -953,57 +983,72 @@ abstract class AQueryWriter
 			$sqlParts = explode( ' WHERE ', $sql, 2 );
 			$sql = "{$sqlParts[0]} {$joinSql} WHERE {$sqlParts[1]}";
 		}
+
 		return $sql;
 	}
 
 	/**
 	 * @see QueryWriter::writeJoin
 	 */
-	public function writeJoin( $type, $targetType, $leftRight = 'LEFT', $joinType = 'parent', $overrideLinkType = FALSE )
+	public function writeJoin( $type, $targetType, $leftRight = 'LEFT', $joinType = 'parent', $firstOfChain = TRUE, $suffix = '' )
 	{
 		if ( $leftRight !== 'LEFT' && $leftRight !== 'RIGHT' && $leftRight !== 'INNER' )
 			throw new RedException( 'Invalid JOIN.' );
-		$alias   = $this->esc( $targetType );
+
 		$aliases = OODBBean::getAliases();
 		if ( isset( $aliases[$targetType] ) ) {
-			$destType    = $aliases[$targetType];
+			$destType      = $aliases[$targetType];
+			$asTargetTable = $this->esc( $targetType.$suffix );
 		} else {
-			$destType    = $targetType;
+			$destType      = $targetType;
+			$asTargetTable = $this->esc( $destType.$suffix );
 		}
-		$table       = $this->esc( $type );
-		$targetTable = $this->esc( $destType );
+
+		if ( $firstOfChain ) {
+			$table = $this->esc( $type );
+		} else {
+			$table = $this->esc( $type.$suffix );
+		}
+		$targetTable   = $this->esc( $destType );
+
 		if ( $joinType == 'shared' ) {
-			$field      = $this->esc((isset($aliases[$type])) ? $aliases[$type] : $type, TRUE);
+			$field      = $this->esc( $type, TRUE );
 			$leftField  = "id";
+			$rightField = "{$field}_id";
+
 			if ( isset( $aliases[$type] ) ) {
-				$linkTable      = $this->esc( $this->getAssocTable( array( ($overrideLinkType) ? $overrideLinkType : $aliases[$type], $destType ) ) );
+				$linkTable      = $this->esc( $this->getAssocTable( array( $aliases[$type], $destType ) ) );
 			} else {
-				$linkTable      = $this->esc( $this->getAssocTable( array( ($overrideLinkType) ? $overrideLinkType : $type, $destType ) ) );
+				$linkTable      = $this->esc( $this->getAssocTable( array( $type, $destType ) ) );
 			}
 			$linkField      = $this->esc( $destType, TRUE );
-			$rightField     = ($overrideLinkType) ? "{$overrideLinkType}_id" :"{$field}_id";
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
-			$joinSql = "
-					{$leftRight} JOIN {$linkTable} ON {$table}.{$leftField} = {$linkTable}.{$rightField}
-					INNER JOIN {$targetTable} AS {$alias} ON {$alias}.{$linkLeftField} = {$linkTable}.{$linkRightField}
-			";
+
+			$joinSql = " {$leftRight} JOIN ( {$linkTable} INNER JOIN {$targetTable}";
+			if ( isset( $aliases[$targetType] ) || $suffix ) {
+				$joinSql .= " AS {$asTargetTable}";
+			}
+			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}";
+			$joinSql .= " ) ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );
-				$leftField  = ($overrideLinkType) ? "{$overrideLinkType}_id" :"{$field}_id";
+				$leftField  = "{$field}_id";
 				$rightField = "id";
 			} else {
 				$field      = $this->esc( $targetType, TRUE );
 				$leftField  = "id";
 				$rightField = "{$field}_id";
 			}
-			if ( isset( $aliases[$targetType] ) ) {
-				$joinSql = " {$leftRight} JOIN {$targetTable} AS {$alias} ON {$alias}.{$leftField} = {$table}.{$rightField} ";
-			} else {
-				$joinSql = " {$leftRight} JOIN {$targetTable} ON {$targetTable}.{$leftField} = {$table}.{$rightField} ";
+
+			$joinSql = " {$leftRight} JOIN {$targetTable}";
+			if ( isset( $aliases[$targetType] ) || $suffix ) {
+				$joinSql .= " AS {$asTargetTable}";
 			}
+			$joinSql .= " ON {$asTargetTable}.{$leftField} = {$table}.{$rightField} ";
 		}
+
 		return $joinSql;
 	}
 
@@ -1347,17 +1392,17 @@ abstract class AQueryWriter
 			$bindings[$idSlot] = $id;
 		}
 		$sql = $this->glueSQLCondition( $addSql, QueryWriter::C_GLUE_WHERE );
-		$sql = $this->parseJoin( 'tree', $sql, $type );
+		$sql = $this->parseJoin( 'redbeantree', $sql, $type );
 		$rows = $this->adapter->get("
-			WITH RECURSIVE tree AS
+			WITH RECURSIVE redbeantree AS
 			(
 				SELECT *
 				FROM {$type} WHERE {$type}.id = {$idSlot}
 				UNION ALL
 				SELECT {$type}.* FROM {$type}
-				INNER JOIN tree {$alias} ON {$direction}
+				INNER JOIN redbeantree {$alias} ON {$direction}
 			)
-			SELECT tree.* FROM tree {$sql};",
+			SELECT redbeantree.* FROM redbeantree {$sql};",
 			$bindings
 		);
 		return $rows;

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1024,11 +1024,11 @@ abstract class AQueryWriter
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
 
-			$joinSql = " {$leftRight} JOIN ( {$linkTable} INNER JOIN {$targetTable}";
+			$joinSql = " {$leftRight} JOIN {$linkTable} INNER JOIN {$targetTable}";
 			if ( isset( $aliases[$targetType] ) || $suffix ) {
 				$joinSql .= " AS {$asTargetTable}";
 			}
-			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField} ) ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
+			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField} ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1024,12 +1024,12 @@ abstract class AQueryWriter
 			$linkLeftField  = "id";
 			$linkRightField = "{$linkField}_id";
 
-			$joinSql = " {$leftRight} JOIN {$linkTable} ON {$table}.{$leftField} = {$linkTable}.{$rightField} ";
-			$joinSql = " {$leftRight} JOIN {$targetTable}";
+			$joinSql = " {$leftRight} JOIN {$linkTable} ON {$table}.{$leftField} = {$linkTable}.{$rightField}";
+			$joinSql .= " {$leftRight} JOIN {$targetTable}";
 			if ( isset( $aliases[$targetType] ) || $suffix ) {
 				$joinSql .= " AS {$asTargetTable}";
 			}
-			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}"
+			$joinSql .= " ON {$asTargetTable}.{$linkLeftField} = {$linkTable}.{$linkRightField}";
 		} else {
 			if ( $joinType == 'own' ) {
 				$field      = $this->esc( $type, TRUE );


### PR DESCRIPTION
Ok so, here's my take on this.
The differences are:

- Should work for SQL written without space like `(@joined.owner.name=?)OR(@joined.owner.status=?)`
- Should work when joining the same table multiple times using aliases
- Shouldn't join a table that has already been joined (`@joined.owner.name = ? OR @joined.owner.own.dog.name = ?` should only join `owner` once)
- Probably still works for CTE, can't test so I'll wait for Travis