### PR TITLE
Add via to brack notation for @ syntax

### DIFF
--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -1026,10 +1026,18 @@ abstract class AQueryWriter
 
 			if ( isset( $globalAliases[$type] ) ) {
 				$field      = $this->esc( $globalAliases[$type], TRUE );
-				$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $globalAliases[$type], $destType ) );
+				if ( $aliases && count( $aliases ) === 1 ) {
+					$assocTable = reset( $aliases );
+				} else {
+					$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $globalAliases[$type], $destType ) );
+				}
 			} else {
 				$field      = $this->esc( $type, TRUE );
-				$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $type, $destType ) );
+				if ( $aliases && count( $aliases ) === 1 ) {
+					$assocTable = reset( $aliases );
+				} else {
+					$assocTable = $this->getAssocTable( array( $cteType ? $cteType : $type, $destType ) );
+				}
 			}
 			$linkTable      = $this->esc( $assocTable );
 			$asLinkTable    = $this->esc( $assocTable.$suffix );


### PR DESCRIPTION
This adds a bracket notation for `@shared` syntax which acts like `via()`.
```php
/*
 * Following the example from https://redbeanphp.com/index.php?p=/many_to_many
 * Let's retrieve projects which Bob is linked to
*/
$projects = R::find('project', ' @shared.employee[via:participant].name LIKE ? ', ['Bob']);
```