### PR TITLE
store() functionality to ODBBean object

### DIFF
--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -1364,6 +1364,10 @@ class OODBBean implements\IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 	 */
 	public function __call( $method, $args )
 	{
+		if($method == 'store'){
+			$this->beanHelper->getToolbox()->getRedBean()->store($this);
+		}
+		
 		if ( empty( $this->__info['model'] ) ) {
 			return NULL;
 		}


### PR DESCRIPTION
Rather than using R::store($books)
We can directly do $books->store()

this syntax of storing model is widely use