### PR TITLE
Start experiment with 'literal-string' type

### DIFF
--- a/RedBeanPHP/Facade.php
+++ b/RedBeanPHP/Facade.php
@@ -985,6 +985,9 @@ class Facade
 	 * @param array  $bindings array of values to be bound to parameters in query
 	 * @param string $snippet  SQL snippet to include in query (for example: FOR UPDATE)
 	 *
+	 * @phpstan-param literal-string|null $sql
+	 * @psalm-param   literal-string|null $sql
+	 *
 	 * @return array
 	 */
 	public static function find( $type, $sql = NULL, $bindings = array(), $snippet = NULL )


### PR DESCRIPTION
Hi Gabor,

Following on from our emails in April, looking at these kinds of mistakes:

```php
$users = R::find('user', 'id = ' . $_GET['id']); // INSECURE
$users = R::find('user', 'id = ?', [$_GET['id']]); // Correct
```

While the [is_literal()](https://wiki.php.net/rfc/is_literal) RFC didn't pass (I'll try again next year, once I've addressed the concerns people had), a very similar check has now been added to [Psalm 4.8](https://github.com/vimeo/psalm/releases/tag/4.8.0) and [PHPStan 0.12.97](https://github.com/phpstan/phpstan/releases/tag/0.12.97) via the `literal-string` type.

This allows RedBeanPHP to note that certain method parameters expect a string created by the developer (defined in the source code, not containing unsafe user data), so mistakes that lead to Injection Vulnerabilities can be identified by anyone using Psalm (level 3 or stricter) or PHPStan (level 7 or stricter)... this will typically help teams who use these tools to identify mistakes from junior developers making "quick edits".

As I don't want to create issues for the users of RedBeanPHP, I'd like to start with the `$sql` parameter in `R::find()` (all this PR does)... this will allow us to see if we get any feedback (I'm happy to help with that), and if it goes well, I can update the other methods.

I appreciate this isn't as good as being able to conditionally apply this check (e.g. with the "novice" mode), and it only works for those using static analysis, but it works, and it's just as forgiving as the original RFC - in that it works with variables, and allows string concatenation (assuming both are `literal-string` values), so things like conditional where clauses are still fine, e.g.

```php
$type_where = 'type ' . ($like ? 'LIKE' : 'NOT LIKE') . ' ?';

$users = R::find('user', $type_where, [$_GET['type']]); // Fine