### PR TITLE
fixing excessive memory usage

### DIFF
--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -541,7 +541,9 @@ class RPDO implements Driver
 	public function GetAll( $sql, $bindings = array() )
 	{
 		$this->runQuery( $sql, $bindings );
-		return $this->resultArray;
+		$result_array = $this->resultArray;
+		$this->resultArray = null;
+		return $result_array;
 	}
 
 	/**
@@ -553,7 +555,9 @@ class RPDO implements Driver
 				'fetchStyle' => \PDO::FETCH_ASSOC
 			)
 		);
-		return $this->resultArray;
+		$result_array = $this->resultArray;
+		$this->resultArray = null;
+		return $result_array;
 	}
 
 	/**
@@ -561,18 +565,18 @@ class RPDO implements Driver
 	 */
 	public function GetCol( $sql, $bindings = array() )
 	{
-		$rows = $this->GetAll( $sql, $bindings );
+		$this->runQuery( $sql, $bindings, array(
+				'fetchStyle' => \PDO::FETCH_COLUMN
+			)
+		);
+		$result_array = $this->resultArray;
+		$this->resultArray = null;
 
-		if ( empty( $rows ) || !is_array( $rows ) ) {
+		if ( empty( $result_array ) || !is_array( $result_array ) ) {
 			return array();
 		}
 
-		$cols = array();
-		foreach ( $rows as $row ) {
-			$cols[] = reset( $row );
-		}
-
-		return $cols;
+		return $result_array;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the issue https://github.com/gabordemooij/redbean/issues/960

I am not sure the
```php
if ( empty( $result_array ) || !is_array( $result_array ) ) {
    return array();
}
```
code in `GetCol()` is still required. I've left it be.

I am not sure `'fetchStyle' => \PDO::FETCH_COLUMN` will work without the 2nd parameter, especially on databases other than mysql. It works for me.

I have tried changing `runQuery()` code to have a return instead of side-effectively setting a field,
<details>
<summary>it looked something like this</summary>

```php
public function runQuery( $sql, $bindings, $options = array() )
{
    $this->connect();
    if ( $this->loggingEnabled && $this->logger ) {
        $this->logger->log( $sql, $bindings );
    }

    $result_array = null;
    try {
        if ( strpos( 'pgsql', $this->dsn ) === 0 ) {
            if (defined('\\PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT')) {
                        $statement = @$this->pdo->prepare($sql, array(\PDO::PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT => TRUE));
                    } else {
                        $statement = $this->pdo->prepare($sql);
                    }
        } else {
            $statement = $this->pdo->prepare( $sql );
        }
        $this->bindParams( $statement, $bindings );
        $statement->execute();
        $this->queryCounter ++;
        $this->affectedRows = $statement->rowCount();
        if ( isset( $options['noFetch'] ) && $options['noFetch'] ) {
            return $statement;
        }

        if ( $statement->columnCount() ) {
            $fetchStyle = ( isset( $options['fetchStyle'] ) ) ? $options['fetchStyle'] : NULL;
            if ( is_null( $fetchStyle) ) {
                $result_array = $statement->fetchAll();
            } else {
                $result_array = $statement->fetchAll( $fetchStyle );
            }

            if ( $this->loggingEnabled && $this->logger ) {
                $this->logger->log( 'resultset: ' . count( $result_array ) . ' rows' );
            }
        }
    } catch ( \PDOException $e ) {
        //Unfortunately the code field is supposed to be int by default (php)
        //So we need a property to convey the SQL State code.
        $err = $e->getMessage();
        if ( $this->loggingEnabled && $this->logger ) $this->logger->log( 'An error occurred: ' . $err );
        $exception = new SQL( $err, 0, $e );
        $exception->setSQLState( $e->getCode() );
        $exception->setDriverDetails( $e->errorInfo );
        throw $exception;
    }

    return $result_array === null ?
        array() :
        $result_array;
}
```
</details>

, but it is already a mess anyway, with multiple returns of different types and severe depth, so I decided to not touch it.

I am not sure this code runs and passes tests, as I have not compiled and ran tests on it.

I have edited `rb-mysql.php` inline though, and it works excellently. Fast and x5+ less RAM.