### PR TITLE
Fix MariaDB detection

### DIFF
--- a/RedBeanPHP/QueryWriter/MySQL.php
+++ b/RedBeanPHP/QueryWriter/MySQL.php
@@ -178,7 +178,7 @@ class MySQL extends AQueryWriter implements QueryWriter
 		if (!isset($options['noInitcode']))
 		$this->adapter->setInitCode(function($version) use(&$me) {
 			try {
-				if (strpos($version, 'maria')===FALSE && intval($version)>=8) {
+				if (strpos(strtolower($version), 'maria')===FALSE && intval($version)>=8) {
 						$me->useFeature('ignoreDisplayWidth');
 				}
 			} catch( \Exception $e ){}


### PR DESCRIPTION
The ``$version`` variable in my MariaDB installation contains the string ``10.4.32-MariaDB``.

Because of the uppercase letter M, this was falsely detected as MySQL > 8, which broke the detection of integer fields and prevented MariaDB from modifying the schema in fluid mode (all integer fields were detected as ``C_DATATYPE_SPECIFIED``).