### PR TITLE
fix usage of non-canonical cast names

### DIFF
--- a/RedBeanPHP/Driver/RPDO.php
+++ b/RedBeanPHP/Driver/RPDO.php
@@ -394,7 +394,7 @@ class RPDO implements Driver
 	 */
 	public function setUseStringOnlyBinding( $yesNo )
 	{
-		$this->flagUseStringOnlyBinding = (boolean) $yesNo;
+		$this->flagUseStringOnlyBinding = (bool) $yesNo;
 		if ( $this->loggingEnabled && $this->logger && method_exists($this->logger,'setUseStringOnlyBinding')) {
 			$this->logger->setUseStringOnlyBinding( $this->flagUseStringOnlyBinding );
 		}
@@ -885,7 +885,7 @@ class RPDO implements Driver
 	 */
 	public function setEnableLogging( $enable )
 	{
-		$this->loggingEnabled = (boolean) $enable;
+		$this->loggingEnabled = (bool) $enable;
 		return $this;
 	}
 

--- a/RedBeanPHP/Logger/RDefault/Debug.php
+++ b/RedBeanPHP/Logger/RDefault/Debug.php
@@ -264,7 +264,7 @@ class Debug extends RDefault implements Logger
 	 */
 	public function setUseStringOnlyBinding( $yesNo = false )
 	{
-		$this->flagUseStringOnlyBinding = (boolean) $yesNo;
+		$this->flagUseStringOnlyBinding = (bool) $yesNo;
 		return $this;
 	}
 }

--- a/RedBeanPHP/OODB.php
+++ b/RedBeanPHP/OODB.php
@@ -99,7 +99,7 @@ class OODB extends Observable
 	 */
 	public static function autoClearHistoryAfterStore( $autoClear = TRUE )
 	{
-		self::$autoClearHistoryAfterStore = (boolean) $autoClear;
+		self::$autoClearHistoryAfterStore = (bool) $autoClear;
 	}
 
 	/**
@@ -185,7 +185,7 @@ class OODB extends Observable
 			$this->chillList = $toggle;
 			$this->isFrozen  = FALSE;
 		} else {
-			$this->isFrozen = (boolean) $toggle;
+			$this->isFrozen = (bool) $toggle;
 		}
 
 		if ( $this->isFrozen ) {
@@ -236,7 +236,7 @@ class OODB extends Observable
 	 */
 	public function isChilled( $type )
 	{
-		return (boolean) ( in_array( $type, $this->chillList ) );
+		return (bool) ( in_array( $type, $this->chillList ) );
 	}
 
 	/**

--- a/RedBeanPHP/OODBBean.php
+++ b/RedBeanPHP/OODBBean.php
@@ -172,7 +172,7 @@ class OODBBean implements \IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 	 */
 	 public static function setEnforceUTF8encoding( $toggle )
 	 {
-		 self::$enforceUTF8encoding = (boolean) $toggle;
+		 self::$enforceUTF8encoding = (bool) $toggle;
 	 }
 
 	/**
@@ -1117,7 +1117,7 @@ class OODBBean implements \IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 		$differentAlias = ($hasAlias && $isOwn && isset($this->__info['sys.alias.'.$listName])) ?
 									($this->__info['sys.alias.'.$listName] !== $this->aliasName) : FALSE;
 		$hasSQL         = ($this->withSql !== '' || $this->via !== NULL);
-		$hasAll         = (boolean) ($this->all);
+		$hasAll         = (bool) ($this->all);
 
 		//If exists and no list or exits and list not changed, bail out.
 		if ( $exists && ((!$isOwn && !$isShared ) || (!$hasSQL && !$differentAlias && !$hasAll)) ) {
@@ -2226,7 +2226,7 @@ class OODBBean implements \IteratorAggregate,\ArrayAccess,\Countable,Jsonable
 			$count = $redbean->getAssociationManager()->relatedCount( $this, $type, $this->withSql, $this->withParams );
 		}
 		$this->clearModifiers();
-		return (integer) $count;
+		return (int) $count;
 	}
 
 	/**

--- a/RedBeanPHP/QueryWriter.php
+++ b/RedBeanPHP/QueryWriter.php
@@ -188,7 +188,7 @@ interface QueryWriter
 	public function getColumns( $type );
 
 	/**
-	 * Returns the Column Type Code (integer) that corresponds
+	 * Returns the Column Type Code (int) that corresponds
 	 * to the given value type. This method is used to determine the minimum
 	 * column type required to represent the given value. There are two modes of
 	 * operation: with or without special types. Scanning without special types

--- a/RedBeanPHP/QueryWriter/AQueryWriter.php
+++ b/RedBeanPHP/QueryWriter/AQueryWriter.php
@@ -344,7 +344,7 @@ abstract class AQueryWriter
 	 */
 	public static function setNarrowFieldMode( $narrowField )
 	{
-		self::$flagNarrowFieldMode = (boolean) $narrowField;
+		self::$flagNarrowFieldMode = (bool) $narrowField;
 	}
 
 	/**
@@ -384,7 +384,7 @@ abstract class AQueryWriter
 	 */
 	public static function setSQLFilters( $sqlFilters, $safeMode = FALSE )
 	{
-		self::$flagSQLFilterSafeMode = (boolean) $safeMode;
+		self::$flagSQLFilterSafeMode = (bool) $safeMode;
 		self::$sqlFilters = $sqlFilters;
 	}
 

--- a/RedBeanPHP/Util/DispenseHelper.php
+++ b/RedBeanPHP/Util/DispenseHelper.php
@@ -39,7 +39,7 @@ class DispenseHelper
 	 */
 	public static function setEnforceNamingPolicy( $yesNo )
 	{
-		self::$enforceNamingPolicy = (boolean) $yesNo;
+		self::$enforceNamingPolicy = (bool) $yesNo;
 	}
 
 	/**

--- a/RedBeanPHP/Util/QuickExport.php
+++ b/RedBeanPHP/Util/QuickExport.php
@@ -57,7 +57,7 @@ class QuickExport
 		$out = '';
 		switch( $name ) {
 			case 'test':
-				self::$test = (boolean) $arg1;
+				self::$test = (bool) $arg1;
 				break;
 			case 'header':
 				$out = ( self::$test ) ? $arg1 : header( $arg1, $arg2 );

--- a/testing/RedUNIT/Base/Bean.php
+++ b/testing/RedUNIT/Base/Bean.php
@@ -1050,12 +1050,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), TRUE );
+		asrt( (bool) ($book->author), TRUE );
 		unset( $book->author );
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), TRUE );
+		asrt( (bool) ($book->author), TRUE );
 	}
 
 	/**
@@ -1067,12 +1067,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), TRUE );
+		asrt( (bool) ($book->author), TRUE );
 		$book->author = NULL;
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), FALSE );
+		asrt( (bool) ($book->author), FALSE );
 	}
 
 	/**
@@ -1084,12 +1084,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), TRUE );
+		asrt( (bool) ($book->author), TRUE );
 		$book->author = FALSE;
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->author), FALSE );
-		asrt( (boolean) ($book->author), FALSE );
+		asrt( (bool) ($book->author), FALSE );
 	}
 
 	/**
@@ -1101,12 +1101,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), TRUE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), TRUE );
 		unset( $book->fetchAs('author')->coauthor );
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), TRUE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), TRUE );
 	}
 
 	/**
@@ -1118,12 +1118,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), TRUE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), TRUE );
 		$book->fetchAs('author')->coauthor = NULL;
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), FALSE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), FALSE );
 	}
 
 	/**
@@ -1135,12 +1135,12 @@ class Bean extends Base
 	{
 		$book = $this->_createBook();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), TRUE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), TRUE );
 		$book->fetchAs('author')->coauthor = FALSE;
 		R::store( $book );
 		$book = $book->fresh();
 		asrt( isset($book->fetchAs('author')->coauthor), FALSE );
-		asrt( (boolean) ($book->fetchAs('author')->coauthor), FALSE );
+		asrt( (bool) ($book->fetchAs('author')->coauthor), FALSE );
 	}
 
 	/**

--- a/testing/RedUNIT/Base/Finding.php
+++ b/testing/RedUNIT/Base/Finding.php
@@ -227,7 +227,7 @@ class Finding extends Base {
 		R::nuke();
 		R::freeze(TRUE);
 		for($i=0;$i<10;$i++) {
-			R::freeze((boolean)($i));
+			R::freeze((bool)($i));
 			$book = R::dispense('book');
 			$book->title = "book{$i}";
 			list($pages) = R::dispenseAll('page*2');

--- a/testing/RedUNIT/Base/Partial.php
+++ b/testing/RedUNIT/Base/Partial.php
@@ -97,13 +97,13 @@ class Partial extends Base {
 		/* test baseline condition */
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 60 );
+		asrt( (int) $book->pages, 60 );
 		$book->pages++;
 		R::exec( 'UPDATE book SET title = ? ', array( 'Another Title' ) );
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 61 );
+		asrt( (int) $book->pages, 61 );
 		/* now test partial beans mode */
 		R::usePartialBeans( TRUE );
 		$book->pages++;
@@ -111,15 +111,15 @@ class Partial extends Base {
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->pages, 62 );
+		asrt( (int) $book->pages, 62 );
 		/* mask should be cleared... */
 		R::exec( 'UPDATE book SET pages = ? ', array( 64 ) );
 		$book->price = 92;
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
-		asrt( (integer) $book->pages, 64 );
+		asrt( (int) $book->pages, 64 );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->price, 92 );
+		asrt( (int) $book->price, 92 );
 		R::usePartialBeans( FALSE );
 	}
 
@@ -141,13 +141,13 @@ class Partial extends Base {
 		/* test baseline condition */
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 60 );
+		asrt( (int) $book->pages, 60 );
 		$book->pages++;
 		R::exec( 'UPDATE book SET title = ? ', array( 'Another Title' ) );
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 61 );
+		asrt( (int) $book->pages, 61 );
 		/* now test partial beans mode */
 		R::usePartialBeans( array( 'book', 'more' ) );
 		$book->pages++;
@@ -155,15 +155,15 @@ class Partial extends Base {
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->pages, 62 );
+		asrt( (int) $book->pages, 62 );
 		/* mask should be cleared... */
 		R::exec( 'UPDATE book SET pages = ? ', array( 64 ) );
 		$book->price = 92;
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
-		asrt( (integer) $book->pages, 64 );
+		asrt( (int) $book->pages, 64 );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->price, 92 );
+		asrt( (int) $book->price, 92 );
 		R::usePartialBeans( FALSE );
 	}
 
@@ -185,13 +185,13 @@ class Partial extends Base {
 		/* test baseline condition */
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 60 );
+		asrt( (int) $book->pages, 60 );
 		$book->pages++;
 		R::exec( 'UPDATE book SET title = ? ', array( 'Another Title' ) );
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 61 );
+		asrt( (int) $book->pages, 61 );
 		/* now test partial beans mode */
 		R::freeze( TRUE );
 		R::usePartialBeans( TRUE );
@@ -200,15 +200,15 @@ class Partial extends Base {
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->pages, 62 );
+		asrt( (int) $book->pages, 62 );
 		/* mask should be cleared... */
 		R::exec( 'UPDATE book SET pages = ? ', array( 64 ) );
 		$book->price = 92;
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
-		asrt( (integer) $book->pages, 64 );
+		asrt( (int) $book->pages, 64 );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->price, 92 );
+		asrt( (int) $book->price, 92 );
 		R::usePartialBeans( FALSE );
 		R::freeze( FALSE );
 	}
@@ -232,13 +232,13 @@ class Partial extends Base {
 		/* test baseline condition */
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 60 );
+		asrt( (int) $book->pages, 60 );
 		$book->pages++;
 		R::exec( 'UPDATE book SET title = ? ', array( 'Another Title' ) );
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'A book about half beans' );
-		asrt( (integer) $book->pages, 61 );
+		asrt( (int) $book->pages, 61 );
 		/* now test partial beans mode */
 		R::freeze( TRUE );
 		R::usePartialBeans( array( 'book', 'more' ) );
@@ -247,15 +247,15 @@ class Partial extends Base {
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->pages, 62 );
+		asrt( (int) $book->pages, 62 );
 		/* mask should be cleared... */
 		R::exec( 'UPDATE book SET pages = ? ', array( 64 ) );
 		$book->price = 92;
 		$id = R::store( $book );
 		$book = R::load( 'book', $id );
-		asrt( (integer) $book->pages, 64 );
+		asrt( (int) $book->pages, 64 );
 		asrt( $book->title, 'Another Title' );
-		asrt( (integer) $book->price, 92 );
+		asrt( (int) $book->price, 92 );
 		R::usePartialBeans( FALSE );
 		R::freeze( FALSE );
 	}


### PR DESCRIPTION
Fixes #964

## Background

Changes in PHP8.5:
Non-canonical cast names (boolean), (integer), (double), and (binary) have been deprecated, use (bool), (int), (float), and (string) respectively.
Source:
https://www.php.net/manual/de/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names