### PR TITLE
Autoload Functions.php through composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "php": ">=5.3.4"
   },
   "autoload": {
+    "files": [
+      "RedBeanPHP/Functions.php"
+    ],
     "psr-4": {
       "RedBeanPHP\\" : "RedBeanPHP"
     }


### PR DESCRIPTION
Added `Functions.php` to composer's autoload section.

This fixes https://github.com/gabordemooij/redbean/issues/972